### PR TITLE
Add <think> / <thinking> tag support via LanguageModelThinkingPart

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -23,9 +23,6 @@ interface ToolCallState {
   finalizedIndices: Set<number>;
   requestId: string;
   toolCallCounter: number;
-
-  // Add error handling for SSE events
-  handleSSEError(error: Error): void;
 }
 
 /**
@@ -34,6 +31,8 @@ interface ToolCallState {
 interface ParsedChunk {
   delta?: {
     content?: string;
+    /** LM Studio / DeepSeek-R1 separate reasoning field */
+    reasoning_content?: string;
     tool_calls?: Array<{
       index?: number;
       id?: string;
@@ -43,6 +42,8 @@ interface ParsedChunk {
   };
   message?: {
     content?: string;
+    /** LM Studio / DeepSeek-R1 separate reasoning field */
+    reasoning_content?: string;
     text?: string;
     tool_calls?: Array<{
       index?: number;
@@ -180,7 +181,7 @@ export class GatewayClient {
   private processDeltaFormat(
     parsed: ParsedChunk,
     state: ToolCallState
-  ): { content: string; finishedToolCalls: StreamingToolCall[] } {
+  ): { content: string; reasoningContent: string; finishedToolCalls: StreamingToolCall[] } {
     const delta = parsed.delta!;
     const finishedToolCalls: StreamingToolCall[] = [];
 
@@ -201,7 +202,7 @@ export class GatewayClient {
       finishedToolCalls.push(...this.finalizeToolCalls(state));
     }
 
-    return { content: delta.content || '', finishedToolCalls };
+    return { content: delta.content || '', reasoningContent: delta.reasoning_content || '', finishedToolCalls };
   }
 
   /**
@@ -210,7 +211,7 @@ export class GatewayClient {
   private processMessageFormat(
     parsed: ParsedChunk,
     state: ToolCallState
-  ): { content: string; finishedToolCalls: StreamingToolCall[] } {
+  ): { content: string; reasoningContent: string; finishedToolCalls: StreamingToolCall[] } {
     const message = parsed.message!;
     const finishedToolCalls: StreamingToolCall[] = [];
 
@@ -240,7 +241,7 @@ export class GatewayClient {
       });
     }
 
-    return { content: message.content || message.text || '', finishedToolCalls };
+    return { content: message.content || message.text || '', reasoningContent: message.reasoning_content || '', finishedToolCalls };
   }
 
   /**
@@ -267,7 +268,7 @@ export class GatewayClient {
   private processSSELine(
     line: string,
     state: ToolCallState
-  ): { content: string; tool_calls: StreamingToolCall[]; finished_tool_calls: StreamingToolCall[] } | null {
+  ): { content: string; reasoning_content: string; tool_calls: StreamingToolCall[]; finished_tool_calls: StreamingToolCall[] } | null {
     const trimmed = line.trim();
 
     if (trimmed === '' || trimmed === 'data: [DONE]') {
@@ -283,13 +284,13 @@ export class GatewayClient {
     if (!parsed) { return null; }
 
     if (parsed.delta) {
-      const { content, finishedToolCalls } = this.processDeltaFormat(parsed, state);
-      return { content, tool_calls: [], finished_tool_calls: finishedToolCalls };
+      const { content, reasoningContent, finishedToolCalls } = this.processDeltaFormat(parsed, state);
+      return { content, reasoning_content: reasoningContent, tool_calls: [], finished_tool_calls: finishedToolCalls };
     }
 
     if (parsed.message) {
-      const { content, finishedToolCalls } = this.processMessageFormat(parsed, state);
-      return { content, tool_calls: [], finished_tool_calls: finishedToolCalls };
+      const { content, reasoningContent, finishedToolCalls } = this.processMessageFormat(parsed, state);
+      return { content, reasoning_content: reasoningContent, tool_calls: [], finished_tool_calls: finishedToolCalls };
     }
 
     return null;
@@ -324,7 +325,7 @@ export class GatewayClient {
   public async *streamChatCompletion(
     request: OpenAIChatCompletionRequest,
     cancellationToken: vscode.CancellationToken
-  ): AsyncGenerator<{ content: string; tool_calls: StreamingToolCall[]; finished_tool_calls: StreamingToolCall[] }, void, unknown> {
+  ): AsyncGenerator<{ content: string; reasoning_content: string; tool_calls: StreamingToolCall[]; finished_tool_calls: StreamingToolCall[] }, void, unknown> {
     const url = `${this.config.serverUrl}/v1/chat/completions`;
     const state = this.createToolCallState();
 
@@ -370,7 +371,7 @@ export class GatewayClient {
       // Finalize any remaining tool calls
       const remaining = this.getRemainingToolCalls(state);
       if (remaining.length > 0) {
-        yield { content: '', tool_calls: [], finished_tool_calls: remaining };
+        yield { content: '', reasoning_content: '', tool_calls: [], finished_tool_calls: remaining };
       }
     } catch (error) {
       if (error instanceof Error) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { GatewayClient } from './client';
 import { GatewayConfig, OpenAIChatCompletionRequest } from './types';
+import { ThinkingParser } from './thinking';
 
 /**
  * Language model provider for OpenAI-compatible inference servers
@@ -372,16 +373,42 @@ export class GatewayProvider implements vscode.LanguageModelChatProvider {
     this.outputChannel.appendLine(`Streaming chat completion...`);
     let totalContent = '';
     let totalToolCalls = 0;
+    let totalTextParts = 0;
+    let hadThinking = false;
+    const parser = new ThinkingParser();
+    let inReasoningField = false;
 
     for await (const chunk of this.client.streamChatCompletion(requestOptions, token)) {
       if (token.isCancellationRequested) {
         break;
       }
 
-      // Report text content immediately
+      // reasoning_content field (LM Studio / DeepSeek-R1 structured output)
+      if (chunk.reasoning_content) {
+        hadThinking = true;
+        inReasoningField = true;
+        progress.report(new vscode.LanguageModelThinkingPart(chunk.reasoning_content));
+      }
+
+      // text content — may contain raw <thinking> tags
       if (chunk.content) {
+        // Close the structured reasoning field when text content starts
+        if (inReasoningField) {
+          inReasoningField = false;
+          progress.report(new vscode.LanguageModelThinkingPart('', '', { vscode_reasoning_done: true }));
+        }
         totalContent += chunk.content;
-        progress.report(new vscode.LanguageModelTextPart(chunk.content));
+        for (const piece of parser.process(chunk.content)) {
+          if (piece.t === 'T') {
+            hadThinking = true;
+            progress.report(new vscode.LanguageModelThinkingPart(piece.c));
+          } else if (piece.t === 'E') {
+            progress.report(new vscode.LanguageModelThinkingPart('', '', { vscode_reasoning_done: true }));
+          } else if (piece.c) {
+            totalTextParts++;
+            progress.report(new vscode.LanguageModelTextPart(piece.c));
+          }
+        }
       }
 
       // Process finished tool calls (fully accumulated by client)
@@ -391,13 +418,12 @@ export class GatewayProvider implements vscode.LanguageModelChatProvider {
           this.outputChannel.appendLine(`Tool call received: id=${toolCall.id}, name=${toolCall.name}`);
           this.outputChannel.appendLine(`  Raw arguments: ${toolCall.arguments.substring(0, 500)}${toolCall.arguments.length > 500 ? '...' : ''}`);
 
-          // Parse arguments with repair capability
           let args = this.tryRepairJson(toolCall.arguments) as Record<string, unknown> | null;
 
           if (args === null) {
             this.outputChannel.appendLine(`ERROR: Failed to parse tool call arguments for ${toolCall.name}`);
             this.outputChannel.appendLine(`  Full arguments: ${toolCall.arguments}`);
-            args = {}; // Fallback to empty args
+            args = {};
           }
 
           progress.report(new vscode.LanguageModelToolCallPart(
@@ -409,7 +435,36 @@ export class GatewayProvider implements vscode.LanguageModelChatProvider {
       }
     }
 
-    this.outputChannel.appendLine(`Completed chat request, received ${totalContent.length} characters, ${totalToolCalls} tool calls`);
+    // Flush any remaining buffered content from the parser
+    let thinkingForceClosed = false;
+    for (const piece of parser.flush()) {
+      if (piece.t === 'T') {
+        hadThinking = true;
+        progress.report(new vscode.LanguageModelThinkingPart(piece.c));
+      } else if (piece.t === 'E') {
+        thinkingForceClosed = true;
+        progress.report(new vscode.LanguageModelThinkingPart('', '', { vscode_reasoning_done: true }));
+      } else if (piece.c) {
+        totalTextParts++;
+        progress.report(new vscode.LanguageModelTextPart(piece.c));
+      }
+    }
+
+    if (inReasoningField) {
+      progress.report(new vscode.LanguageModelThinkingPart('', '', { vscode_reasoning_done: true }));
+    }
+
+    // If thinking was force-closed (stream ended inside a think block, e.g. token limit
+    // reached during thinking), emit a fallback text part so Copilot Chat shows the response.
+    if (thinkingForceClosed && totalTextParts === 0 && totalToolCalls === 0) {
+      progress.report(new vscode.LanguageModelTextPart(
+        '*(The model ran out of output tokens while thinking and could not produce a response. ' +
+        'Try increasing the context length or max output tokens in LM Studio, ' +
+        'or disable thinking for this model.)*'
+      ));
+    }
+
+    this.outputChannel.appendLine(`Completed chat request, received ${totalContent.length} chars, ${totalTextParts} text parts, ${totalToolCalls} tool calls`);
   }
 
   /**
@@ -754,13 +809,39 @@ export class GatewayProvider implements vscode.LanguageModelChatProvider {
     try {
       let totalContent = '';
       let totalToolCalls = 0;
+      let totalTextParts = 0;
+      let hadThinking = false;
+      const parser = new ThinkingParser();
+      let inReasoningField = false;
 
       for await (const chunk of this.client.streamChatCompletion(requestOptions as unknown as OpenAIChatCompletionRequest, token)) {
         if (token.isCancellationRequested) { break; }
 
+        // reasoning_content field (LM Studio / DeepSeek-R1 structured output)
+        if (chunk.reasoning_content) {
+          hadThinking = true;
+          inReasoningField = true;
+          progress.report(new vscode.LanguageModelThinkingPart(chunk.reasoning_content));
+        }
+
+        // text content — may contain raw <thinking> tags
         if (chunk.content) {
+          if (inReasoningField) {
+            inReasoningField = false;
+            progress.report(new vscode.LanguageModelThinkingPart('', '', { vscode_reasoning_done: true }));
+          }
           totalContent += chunk.content;
-          progress.report(new vscode.LanguageModelTextPart(chunk.content));
+          for (const piece of parser.process(chunk.content)) {
+            if (piece.t === 'T') {
+              hadThinking = true;
+              progress.report(new vscode.LanguageModelThinkingPart(piece.c));
+            } else if (piece.t === 'E') {
+              progress.report(new vscode.LanguageModelThinkingPart('', '', { vscode_reasoning_done: true }));
+            } else if (piece.c) {
+              totalTextParts++;
+              progress.report(new vscode.LanguageModelTextPart(piece.c));
+            }
+          }
         }
 
         if (chunk.finished_tool_calls?.length) {
@@ -771,9 +852,39 @@ export class GatewayProvider implements vscode.LanguageModelChatProvider {
         }
       }
 
-      this.outputChannel.appendLine(`Completed chat request, received ${totalContent.length} characters, ${totalToolCalls} tool calls`);
+      // Flush any remaining buffered content from the parser
+      let thinkingForceClosed = false;
+      for (const piece of parser.flush()) {
+        if (piece.t === 'T') {
+          hadThinking = true;
+          progress.report(new vscode.LanguageModelThinkingPart(piece.c));
+        } else if (piece.t === 'E') {
+          thinkingForceClosed = true;
+          progress.report(new vscode.LanguageModelThinkingPart('', '', { vscode_reasoning_done: true }));
+        } else if (piece.c) {
+          totalTextParts++;
+          progress.report(new vscode.LanguageModelTextPart(piece.c));
+        }
+      }
 
-      if (totalContent.length === 0 && totalToolCalls === 0) {
+      if (inReasoningField) {
+        progress.report(new vscode.LanguageModelThinkingPart('', '', { vscode_reasoning_done: true }));
+      }
+
+      // If thinking was force-closed (stream ended inside a think block, e.g. token limit
+      // reached during thinking), emit a fallback text part so Copilot Chat shows the response.
+      if (thinkingForceClosed && totalTextParts === 0 && totalToolCalls === 0) {
+        progress.report(new vscode.LanguageModelTextPart(
+          '*(The model ran out of output tokens while thinking and could not produce a response. ' +
+          'Try increasing the context length or max output tokens in LM Studio, ' +
+          'or disable thinking for this model.)*'
+        ));
+      }
+
+      this.outputChannel.appendLine(`Completed chat request, received ${totalContent.length} chars, ${totalTextParts} text parts, ${totalToolCalls} tool calls`);
+
+      // Only flag empty response if no content, no tool calls AND no thinking AND no fallback was emitted.
+      if (totalContent.length === 0 && totalToolCalls === 0 && !hadThinking && !thinkingForceClosed) {
         await this.handleEmptyResponse(model, inputText, openAIMessages.length, requestOptions.tools ? (requestOptions.tools as unknown[]).length : 0, token, progress);
       }
     } catch (error) {

--- a/src/thinking.ts
+++ b/src/thinking.ts
@@ -1,0 +1,187 @@
+/**
+ * ThinkingParser — streams text through and separates <thinking>/<think> blocks
+ * from regular content, handling tag boundaries that split across SSE chunks.
+ *
+ * Emits items with type:
+ *   't' — regular text content
+ *   'T' — thinking/reasoning content
+ *   'E' — end of a thinking block (vscode_reasoning_done)
+ */
+
+export interface ThinkingChunk {
+  /** 't' = text, 'T' = thinking, 'E' = end-of-thinking */
+  t: 't' | 'T' | 'E';
+  c: string;
+}
+
+const OPEN_TAGS: [string, string][] = [
+  ['<thinking>', '</thinking>'],
+  ['<think>', '</think>'],
+];
+
+// Close tags that should be stripped if seen outside a thinking block
+// (happens when LM Studio routes reasoning_content separately but leaves </think> in content)
+const STRAY_CLOSE_TAGS: string[] = ['</thinking>', '</think>'];
+
+export class ThinkingParser {
+  private buf = '';
+  private inThink = false;
+  private closeTag = '';
+
+  /**
+   * Feed a new streamed chunk. Returns zero or more ThinkingChunks to report.
+   */
+  process(chunk: string): ThinkingChunk[] {
+    this.buf += chunk;
+    const results: ThinkingChunk[] = [];
+
+    while (this.buf.length > 0) {
+      if (this.inThink) {
+        results.push(...this._processInsideThink());
+        if (this.inThink) {
+          // Still inside tag and no close tag found — hold partial tail and wait
+          break;
+        }
+      } else {
+        const advanced = this._processOutsideThink(results);
+        if (!advanced) { break; }
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Call after the stream ends to flush any remaining buffered content.
+   */
+  flush(): ThinkingChunk[] {
+    const results: ThinkingChunk[] = [];
+
+    if (this.buf.length > 0) {
+      results.push({ t: this.inThink ? 'T' : 't', c: this.buf });
+      this.buf = '';
+    }
+
+    if (this.inThink) {
+      results.push({ t: 'E', c: '' });
+      this.inThink = false;
+      this.closeTag = '';
+    }
+
+    return results;
+  }
+
+  // ---- private helpers ----
+
+  private _processInsideThink(): ThinkingChunk[] {
+    const results: ThinkingChunk[] = [];
+    const ci = this.buf.indexOf(this.closeTag);
+
+    if (ci >= 0) {
+      // Found the closing tag
+      if (ci > 0) {
+        results.push({ t: 'T', c: this.buf.slice(0, ci) });
+      }
+      results.push({ t: 'E', c: '' });
+      this.buf = this.buf.slice(ci + this.closeTag.length);
+      this.inThink = false;
+      this.closeTag = '';
+    } else {
+      // Closing tag not yet seen — emit safe prefix, hold possible partial tag tail
+      const hold = this._partialSuffixLen(this.closeTag);
+      const safe = this.buf.length - hold;
+      if (safe > 0) {
+        results.push({ t: 'T', c: this.buf.slice(0, safe) });
+        this.buf = this.buf.slice(safe);
+      }
+      // If nothing advanced, caller breaks out of the while loop
+    }
+
+    return results;
+  }
+
+  private _processOutsideThink(results: ThinkingChunk[]): boolean {
+    // Find which opening tag appears first
+    let best = -1;
+    let bOpen = '';
+    let bClose = '';
+
+    for (const [ot, ct] of OPEN_TAGS) {
+      const i = this.buf.indexOf(ot);
+      if (i >= 0 && (best < 0 || i < best)) {
+        best = i;
+        bOpen = ot;
+        bClose = ct;
+      }
+    }
+
+    // Also check for stray close tags (e.g. LM Studio sends </think> in content
+    // when it already routed the thinking body through reasoning_content).
+    // If a close tag appears before any open tag, strip it silently.
+    for (const ct of STRAY_CLOSE_TAGS) {
+      const i = this.buf.indexOf(ct);
+      if (i >= 0 && (best < 0 || i < best)) {
+        // Emit text before the stray close tag, then discard the tag itself
+        if (i > 0) {
+          results.push({ t: 't', c: this.buf.slice(0, i) });
+        }
+        this.buf = this.buf.slice(i + ct.length);
+        return true;
+      }
+    }
+
+    if (best >= 0) {
+      // Emit text before the opening tag
+      if (best > 0) {
+        results.push({ t: 't', c: this.buf.slice(0, best) });
+      }
+      this.buf = this.buf.slice(best + bOpen.length);
+      this.inThink = true;
+      this.closeTag = bClose;
+      return true;
+    }
+
+    // No opening tag found — emit safe prefix (hold partial opening tag tail)
+    const hold = this._partialOpenTagSuffixLen();
+    const safe = this.buf.length - hold;
+
+    if (safe > 0) {
+      results.push({ t: 't', c: this.buf.slice(0, safe) });
+      this.buf = this.buf.slice(safe);
+      return true;
+    }
+
+    return false; // Nothing advanced
+  }
+
+  /**
+   * How many trailing bytes of `buf` could be the start of `tag`?
+   * Used to avoid emitting bytes that might be part of an incoming tag.
+   */
+  private _partialSuffixLen(tag: string): number {
+    for (let i = tag.length - 1; i > 0; i--) {
+      if (this.buf.endsWith(tag.slice(0, i))) {
+        return i;
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * How many trailing bytes of `buf` could be the start of ANY opening tag?
+   * Only hold based on opening tags — stray close tags are stripped on sight,
+   * not anticipated speculatively.
+   */
+  private _partialOpenTagSuffixLen(): number {
+    let hold = 0;
+    for (const [ot] of OPEN_TAGS) {
+      for (let i = ot.length - 1; i > 0; i--) {
+        if (this.buf.endsWith(ot.slice(0, i)) && i > hold) {
+          hold = i;
+          break;
+        }
+      }
+    }
+    return hold;
+  }
+}

--- a/src/vscode-extensions.d.ts
+++ b/src/vscode-extensions.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Type augmentations for VS Code APIs that exist at runtime but are not yet
+ * present in the @types/vscode version this project targets.
+ */
+import 'vscode';
+
+declare module 'vscode' {
+  /**
+   * A part of a language model response that contains reasoning/thinking content.
+   * Copilot Chat renders this in a dedicated collapsible "Thinking" UI block.
+   *
+   * @param value   The thinking text for this chunk.
+   * @param id      Optional identifier for the thinking block (used for Anthropic extended thinking).
+   * @param metadata  Optional metadata. Pass `{ vscode_reasoning_done: true }` to close the block.
+   */
+  export class LanguageModelThinkingPart {
+    readonly value: string;
+    readonly id: string | undefined;
+    readonly metadata: Record<string, unknown> | undefined;
+    constructor(value: string, id?: string, metadata?: Record<string, unknown>);
+  }
+}


### PR DESCRIPTION
## Add `<think>` / `<thinking>` tag support via `LanguageModelThinkingPart`

### Problem

Reasoning models (DeepSeek-R1, Qwen3, etc.) stream their internal chain-of-thought
inline in `delta.content` wrapped in `<think>…</think>` tags. The extension was
forwarding these raw tags as plain `LanguageModelTextPart`s, so the thinking monologue
appeared verbatim in the Copilot Chat response — cluttering answers and exposing model
internals.

Some models also populate the separate `reasoning_content` field in the OpenAI-compatible
response delta; that field was also being silently dropped.

### Solution

**`src/thinking.ts`** _(new)_

Stream state machine (`ThinkingParser`) that buffers SSE chunks and detects
`<think>`/`<thinking>` open/close tags across chunk boundaries. Emits typed pieces:

| Type | Meaning |
|------|---------|
| `'T'` | Thinking content |
| `'t'` | Regular text |
| `'E'` | End-of-thinking block |

`flush()` force-closes any block left open when the stream ends (e.g. context-limit hit
mid-think).

---

**`src/vscode-extensions.d.ts`** _(new)_

Type declaration for `vscode.LanguageModelThinkingPart`, which exists at runtime in
VS Code ≥ 1.106 but is not yet in `@types/vscode@1.106.0`.

---

**`src/client.ts`**

Added `reasoning_content?: string` to `ParsedChunk` delta/message interfaces and
threaded it through `processDeltaFormat`, `processMessageFormat`, `processSSELine`, and
the `streamChatCompletion` generator yield type.

---

**`src/provider.ts`**

Updated the streaming loop in `provideLanguageModelChatResponse` to:

- Route `chunk.reasoning_content` → `LanguageModelThinkingPart` (dedicated field)
- Route `chunk.content` through `ThinkingParser` → either `LanguageModelThinkingPart`
  or `LanguageModelTextPart` depending on whether content is inside a `<think>` block
- Close the thinking block with `{ vscode_reasoning_done: true }` metadata
- Emit a user-facing fallback `TextPart` when the stream ends mid-think (token limit
  reached during reasoning), preventing _"Sorry, no response was returned"_ errors
- Gate `handleEmptyResponse` so thinking-only responses aren't incorrectly flagged empty

### Testing

Verified against LM Studio with:
- `qwen/qwen3.5-9b` — emits `<think>…</think>` as a complete block followed by answer text
- `deepseek/deepseek-r1-0528-qwen3-8b` — emits `</think>` split across multiple SSE chunks
  (handled correctly by the partial-suffix holding logic in `ThinkingParser`)