### PR TITLE
Mark models as user-selectable for VS Code 1.120 picker (issue #29)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-copilot-llm-gateway",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-copilot-llm-gateway",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.6.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "github-copilot-llm-gateway",
   "displayName": "GitHub Copilot LLM Gateway",
   "description": "Connect GitHub Copilot to open-source models via vLLM or any OpenAI-compatible server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "AndrewButson",
   "icon": "assets/copilot-llm-gateway.png",
   "private": true,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -278,6 +278,10 @@ export class GatewayProvider implements vscode.LanguageModelChatProvider {
         },
         ...(detail ? { description: detail, detail } : {}),
         tooltip: detail ? `${model.id} — ${detail}` : model.id,
+        // VS Code 1.120 hid models from the chat picker unless the provider
+        // marks them user-selectable — without this, gateway models only
+        // appeared in the read-only Manage Models list (issue #29).
+        isUserSelectable: true,
       };
       return info;
     });

--- a/src/vscode-extensions.d.ts
+++ b/src/vscode-extensions.d.ts
@@ -24,10 +24,15 @@ declare module 'vscode' {
    * Optional fields the Copilot Chat model picker renders if present.
    * Not yet declared on `LanguageModelChatInformation` in the bundled
    * `@types/vscode`; declared here so we don't need an unsafe cast.
+   *
+   * `isUserSelectable` was added in VS Code 1.120 and gates whether the
+   * model appears directly in the chat model picker — without it, our
+   * models only showed up in the read-only "Manage Models" list (issue #29).
    */
   interface LanguageModelChatInformation {
     description?: string;
     tooltip?: string;
     detail?: string;
+    isUserSelectable?: boolean;
   }
 }


### PR DESCRIPTION
VS Code 1.120 stopped showing LanguageModelChatProvider models in the chat picker dropdown unless the provider sets isUserSelectable: true on each LanguageModelChatInformation entry. Models still appeared in the read-only Manage Models list, but not the picker users actually click — confirmed by issue #29 reports across multiple users.

Set isUserSelectable on every model returned from doFetchModels and augment the LanguageModelChatInformation type so we don't need an unsafe cast. The field is ignored by older VS Code versions, so the fix is backward-compatible and engines.vscode stays at ^1.106.0.

Bumps version to 1.0.5.