### PR TITLE
Address SonarCloud quality issues flagged on the 1.0.5 release branch

### DIFF
--- a/src/__tests__/secretMigration.test.ts
+++ b/src/__tests__/secretMigration.test.ts
@@ -64,7 +64,7 @@ class FakeConfig implements LegacyConfigAccessor {
 }
 
 class FakeSecrets implements SecretAccessor {
-  private store_: Map<string, string> = new Map();
+  private readonly store_: Map<string, string> = new Map();
 
   async get(key: string): Promise<string | undefined> {
     return this.store_.get(key);

--- a/src/client.ts
+++ b/src/client.ts
@@ -115,6 +115,35 @@ const SSE_DATA_PREFIX = 'data: ';
 const SSE_DONE_LINE = 'data: [DONE]';
 const ERROR_PREFIX = 'Inference server reported an error mid-stream: ';
 
+/**
+ * Lifecycle handles for the AbortController + the two timers used by a
+ * streaming chat-completion request. Returned by `createStreamTimers` so the
+ * main streaming function doesn't have to track them inline.
+ */
+interface StreamTimers {
+  readonly controller: AbortController;
+  readonly resetInactivity: () => void;
+  /** Called once response headers arrive — switches to the inactivity timer. */
+  readonly onHeadersReceived: () => void;
+  /** Clears every outstanding timer + cancellation subscription. */
+  readonly dispose: () => void;
+}
+
+/**
+ * Throw a descriptive error for a failed chat-completion response, including
+ * the response body when the server provided one. Pulled out of
+ * `streamChatCompletion` so the main function stays under the
+ * cognitive-complexity budget.
+ */
+async function assertChatStreamResponseOk(response: Response): Promise<void> {
+  if (response.ok && response.body) { return; }
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Chat completion failed: ${response.status} ${response.statusText} - ${errorText}`);
+  }
+  throw new Error('Response body is null');
+}
+
 export class GatewayClient {
   private config: GatewayConfig;
   private readonly log: GatewayLogger;
@@ -201,15 +230,7 @@ export class GatewayClient {
   ): AsyncGenerator<GatewayStreamChunk, void, unknown> {
     const url = `${normalizeBaseUrl(this.config.serverUrl)}/v1/chat/completions`;
     const accumulator = new ToolCallAccumulator();
-
-    const controller = new AbortController();
-    const cancelSub = cancellationToken.onCancellationRequested(() => controller.abort());
-    const headerTimeoutId = setTimeout(() => controller.abort(), this.config.requestTimeout);
-    let inactivityTimeoutId: ReturnType<typeof setTimeout> | undefined;
-    const resetInactivityTimer = (): void => {
-      if (inactivityTimeoutId) { clearTimeout(inactivityTimeoutId); }
-      inactivityTimeoutId = setTimeout(() => controller.abort(), this.config.requestTimeout);
-    };
+    const timers = this.createStreamTimers(cancellationToken);
 
     try {
       const response = await fetch(url, {
@@ -223,47 +244,18 @@ export class GatewayClient {
         body: JSON.stringify({
           ...request,
           stream: true,
-          stream_options: { ...((request.stream_options as object | undefined) ?? {}), include_usage: true },
+          stream_options: { ...(request.stream_options as object | undefined), include_usage: true },
         }),
-        signal: controller.signal,
+        signal: timers.controller.signal,
       });
 
-      // Headers received — switch to the inactivity timer.
-      clearTimeout(headerTimeoutId);
-      resetInactivityTimer();
+      // Headers received — switch from the request-deadline timer to the
+      // per-chunk inactivity timer so long generations aren't aborted.
+      timers.onHeadersReceived();
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        throw new Error(`Chat completion failed: ${response.status} ${response.statusText} - ${errorText}`);
-      }
-      if (!response.body) {
-        throw new Error('Response body is null');
-      }
+      await assertChatStreamResponseOk(response);
 
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = '';
-
-      while (true) {
-        if (cancellationToken.isCancellationRequested) {
-          reader.cancel();
-          break;
-        }
-
-        const { done, value } = await reader.read();
-        if (done) { break; }
-
-        resetInactivityTimer();
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
-
-        for (const line of lines) {
-          const result = this.processSSELine(line, accumulator);
-          if (result) { yield result; }
-        }
-      }
+      yield* this.readChatStreamChunks(response.body!, accumulator, cancellationToken, timers.resetInactivity);
 
       const remaining = accumulator.drain(true);
       if (remaining.length > 0) {
@@ -275,10 +267,76 @@ export class GatewayClient {
       }
       throw error;
     } finally {
-      clearTimeout(headerTimeoutId);
-      if (inactivityTimeoutId) { clearTimeout(inactivityTimeoutId); }
-      cancelSub.dispose();
+      timers.dispose();
     }
+  }
+
+  /**
+   * Read SSE chunks off the response body until done or cancelled, parsing
+   * each line through {@link processSSELine}. Split out of
+   * `streamChatCompletion` so the parent function stays under SonarCloud's
+   * cognitive-complexity budget.
+   */
+  private async *readChatStreamChunks(
+    body: ReadableStream<Uint8Array>,
+    accumulator: ToolCallAccumulator,
+    cancellationToken: vscode.CancellationToken,
+    resetInactivity: () => void
+  ): AsyncGenerator<GatewayStreamChunk, void, unknown> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      if (cancellationToken.isCancellationRequested) {
+        reader.cancel();
+        return;
+      }
+
+      const { done, value } = await reader.read();
+      if (done) { return; }
+
+      resetInactivity();
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const result = this.processSSELine(line, accumulator);
+        if (result) { yield result; }
+      }
+    }
+  }
+
+  /**
+   * Wire up the AbortController, request-deadline timer, and per-chunk
+   * inactivity timer used by the streaming request. The two timers run
+   * sequentially: the request timer fires until headers arrive, then the
+   * inactivity timer takes over and is reset on each chunk.
+   */
+  private createStreamTimers(cancellationToken: vscode.CancellationToken): StreamTimers {
+    const controller = new AbortController();
+    const cancelSub = cancellationToken.onCancellationRequested(() => controller.abort());
+    const headerTimeoutId = setTimeout(() => controller.abort(), this.config.requestTimeout);
+    let inactivityTimeoutId: ReturnType<typeof setTimeout> | undefined;
+    const resetInactivity = (): void => {
+      if (inactivityTimeoutId) { clearTimeout(inactivityTimeoutId); }
+      inactivityTimeoutId = setTimeout(() => controller.abort(), this.config.requestTimeout);
+    };
+    return {
+      controller,
+      resetInactivity,
+      onHeadersReceived: () => {
+        clearTimeout(headerTimeoutId);
+        resetInactivity();
+      },
+      dispose: () => {
+        clearTimeout(headerTimeoutId);
+        if (inactivityTimeoutId) { clearTimeout(inactivityTimeoutId); }
+        cancelSub.dispose();
+      },
+    };
   }
 
   /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -241,6 +241,11 @@ async function offerAdvancedSettings(provider: GatewayProvider): Promise<void> {
   }
 }
 
+interface HeaderQuickPickItem extends vscode.QuickPickItem {
+  action: 'add' | 'edit' | 'clear' | 'done';
+  headerName?: string;
+}
+
 /**
  * Quick-pick driven editor for custom headers persisted in SecretStorage.
  * Shows only header names (not values) so peeking at someone else's screen
@@ -249,37 +254,8 @@ async function offerAdvancedSettings(provider: GatewayProvider): Promise<void> {
 async function editCustomHeadersFlow(provider: GatewayProvider): Promise<void> {
   while (true) {
     const headers = provider.getCustomHeadersSnapshot();
-    const headerNames = Object.keys(headers).sort();
-
-    interface HeaderItem extends vscode.QuickPickItem {
-      action: 'add' | 'edit' | 'clear' | 'done';
-      headerName?: string;
-    }
-
-    const items: HeaderItem[] = [
-      { label: 'Done', description: 'Save and close', action: 'done' },
-      { label: '$(add) Add header...', description: 'Add a new header', action: 'add' },
-    ];
-    if (headerNames.length > 0) {
-      items.push({
-        label: '$(trash) Clear all headers',
-        description: 'Remove every custom header',
-        action: 'clear',
-      });
-      items.push({
-        label: '',
-        kind: vscode.QuickPickItemKind.Separator,
-        action: 'done',
-      });
-      for (const name of headerNames) {
-        items.push({
-          label: name,
-          description: 'Edit or remove (value hidden)',
-          action: 'edit',
-          headerName: name,
-        });
-      }
-    }
+    const headerNames = Object.keys(headers).sort((a, b) => a.localeCompare(b));
+    const items = buildHeaderQuickPickItems(headerNames);
 
     const pick = await vscode.window.showQuickPick(items, {
       title: `LLM Gateway — Custom Headers (${headerNames.length})`,
@@ -293,22 +269,56 @@ async function editCustomHeadersFlow(provider: GatewayProvider): Promise<void> {
 
     if (pick.action === 'add') {
       await addHeader(provider, headers);
-      continue;
-    }
-    if (pick.action === 'clear') {
-      const confirm = await vscode.window.showWarningMessage(
-        `Remove all ${headerNames.length} custom header(s)?`,
-        { modal: true },
-        'Remove'
-      );
-      if (confirm === 'Remove') {
-        await provider.setCustomHeaders({});
-      }
-      continue;
-    }
-    if (pick.action === 'edit' && pick.headerName) {
+    } else if (pick.action === 'clear') {
+      await confirmAndClearHeaders(provider, headerNames.length);
+    } else if (pick.action === 'edit' && pick.headerName) {
       await editOrDeleteHeader(provider, headers, pick.headerName);
     }
+  }
+}
+
+/**
+ * Build the quick-pick items for the custom-headers editor. Pulled out so
+ * `editCustomHeadersFlow` stays under SonarCloud's cognitive-complexity
+ * budget — and so the item shape lives next to its uses.
+ */
+function buildHeaderQuickPickItems(headerNames: readonly string[]): HeaderQuickPickItem[] {
+  const items: HeaderQuickPickItem[] = [
+    { label: 'Done', description: 'Save and close', action: 'done' },
+    { label: '$(add) Add header...', description: 'Add a new header', action: 'add' },
+  ];
+  if (headerNames.length === 0) {
+    return items;
+  }
+  items.push(
+    {
+      label: '$(trash) Clear all headers',
+      description: 'Remove every custom header',
+      action: 'clear',
+    },
+    {
+      label: '',
+      kind: vscode.QuickPickItemKind.Separator,
+      action: 'done',
+    },
+    ...headerNames.map<HeaderQuickPickItem>((name) => ({
+      label: name,
+      description: 'Edit or remove (value hidden)',
+      action: 'edit',
+      headerName: name,
+    }))
+  );
+  return items;
+}
+
+async function confirmAndClearHeaders(provider: GatewayProvider, count: number): Promise<void> {
+  const confirm = await vscode.window.showWarningMessage(
+    `Remove all ${count} custom header(s)?`,
+    { modal: true },
+    'Remove'
+  );
+  if (confirm === 'Remove') {
+    await provider.setCustomHeaders({});
   }
 }
 
@@ -392,12 +402,12 @@ async function pickConfigurationTarget(
   const inspection = config.inspect('serverUrl');
   const workspacePick: vscode.QuickPickItem = {
     label: 'Workspace Settings',
-    description: inspection?.workspaceValue !== undefined ? '(currently set)' : undefined,
+    description: inspection?.workspaceValue === undefined ? undefined : '(currently set)',
     detail: 'Apply to this workspace only — different VS Code windows can use different servers.',
   };
   const globalPick: vscode.QuickPickItem = {
     label: 'User Settings (Global)',
-    description: inspection?.globalValue !== undefined ? '(currently set)' : undefined,
+    description: inspection?.globalValue === undefined ? undefined : '(currently set)',
     detail: 'Apply to all VS Code windows.',
   };
 

--- a/src/secretMigration.ts
+++ b/src/secretMigration.ts
@@ -109,23 +109,23 @@ export async function migrateLegacySecrets(
 
   if (hasLegacyKey) {
     const existing = await secrets.get(SECRET_KEYS.apiKey);
-    if (!existing) {
+    if (existing) {
+      log('Found legacy apiKey setting but a secret already exists; not overwriting.');
+    } else {
       await secrets.store(SECRET_KEYS.apiKey, legacyApiKey);
       result.apiKeyMigrated = true;
       log('Migrated legacy apiKey setting into SecretStorage.');
-    } else {
-      log('Found legacy apiKey setting but a secret already exists; not overwriting.');
     }
   }
 
   if (hasLegacyHeaders) {
     const existing = await secrets.get(SECRET_KEYS.customHeaders);
-    if (!existing) {
+    if (existing) {
+      log('Found legacy customHeaders setting but a secret already exists; not overwriting.');
+    } else {
       await secrets.store(SECRET_KEYS.customHeaders, JSON.stringify(legacyHeaders));
       result.customHeadersMigrated = true;
       log(`Migrated ${Object.keys(legacyHeaders).length} legacy customHeaders into SecretStorage.`);
-    } else {
-      log('Found legacy customHeaders setting but a secret already exists; not overwriting.');
     }
   }
 


### PR DESCRIPTION
- extension.ts: extract `buildHeaderQuickPickItems` and `confirmAndClearHeaders` helpers so `editCustomHeadersFlow` stays under the cognitive-complexity budget (S3776) and collapse the multiple `Array#push()` calls into a single variadic call (S7778). Sort header names with a `localeCompare` comparator (S2871/BUG) and flip the two negated `!== undefined` ternaries that picked the scope-indicator label (S7735).
- client.ts: extract `readChatStreamChunks`, `createStreamTimers`, and `assertChatStreamResponseOk` so `streamChatCompletion` drops below the complexity ceiling (S3776). Remove the redundant `?? {}` fallback on the `stream_options` spread (S7744) — the empty object is a no-op when spread.
- secretMigration.ts: flip the negated `if (!existing)` branches in the apiKey + customHeaders migration paths (S7735) so the early-return shape doesn't read backwards.
- secretMigration.test.ts: mark the `FakeSecrets` backing map as `readonly` (S2933) — it's only ever mutated, never reassigned.

No behavioural changes; 173 tests still pass and bundle builds at 81.0 kb.