### PR TITLE
fix(ci): publish to Marketplace on semver tag push

### DIFF
--- a/.github/workflows/vsix-package.yaml
+++ b/.github/workflows/vsix-package.yaml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
-  release:
-    types:
-      - created
+    tags:
+      # Publish to the Marketplace on a semver tag push (e.g. 1.2.0).
+      # A tag ref guarantees github.ref == refs/tags/<tag>, which the
+      # publish step below relies on. The previous `release: created`
+      # trigger could fire during the draft phase with the `main` ref,
+      # silently skipping the publish step.
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:


### PR DESCRIPTION
The publish step is gated on github.ref being a tag, but the previous release: created trigger could fire during the draft phase with the main ref, silently skipping the publish (as happened for 1.2.0). Trigger on semver tag pushes so github.ref is always refs/tags/<tag>.