### PR TITLE
Fix/issue 51 vllm suffix fallback (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ VS Code does **not** let bring-your-own-key models power its own inline ("ghost 
 
 **Requirements & notes:**
 
-- Your model/server must support **fill-in-the-middle (FIM)** via the `/v1/completions` `suffix` parameter (vLLM, llama.cpp, LM Studio, and most local servers do). The text before the cursor is sent as `prompt` and the text after as `suffix`.
+- For true **fill-in-the-middle (FIM)**, your server must support the `/v1/completions` `suffix` parameter (llama.cpp, LM Studio, and most local servers do). The text before the cursor is sent as `prompt` and the text after as `suffix`.
+- Servers that reject the `suffix` parameter — notably **vLLM**, which answers `400 "suffix is not currently supported"` — are detected automatically: the extension falls back to **prefix-only** completions (plain continuation of the code before the cursor) for the rest of the session. Completions still work, but the model can't see the code after the cursor.
 - Point **Inline Completion Model** at a code/FIM or `*-base` model for best results — chat-tuned models tend to be slower and chattier for raw completion.
 - If you already use GitHub Copilot's inline suggestions, leave this **off** to avoid two providers competing for the same ghost text.
 - Completions are best-effort: server errors or timeouts simply yield no suggestion (details go to the output channel) rather than interrupting you.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-copilot-llm-gateway",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-copilot-llm-gateway",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "github-copilot-llm-gateway",
   "displayName": "GitHub Copilot LLM Gateway",
   "description": "Connect GitHub Copilot to open-source models via vLLM or any OpenAI-compatible server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "AndrewButson",
   "icon": "assets/copilot-llm-gateway.png",
   "private": true,

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -1,6 +1,12 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
-import { normalizeBaseUrl, normalizeApiKey, buildHeaders, extractUsage } from '../client';
+import {
+  CompletionHttpError,
+  normalizeBaseUrl,
+  normalizeApiKey,
+  buildHeaders,
+  extractUsage,
+} from '../client';
 
 describe('normalizeBaseUrl', () => {
   test('returns the URL unchanged when no normalization is needed', () => {
@@ -164,5 +170,17 @@ describe('extractUsage', () => {
     assert.equal(result?.prompt_tokens, 0);
     assert.equal(result?.completion_tokens, 5);
     assert.equal(result?.total_tokens, 5);
+  });
+});
+
+describe('CompletionHttpError', () => {
+  test('exposes status and raw body for capability-specific handling', () => {
+    const body = '{"error":{"message":"suffix is not currently supported"}}';
+    const err = new CompletionHttpError('Completion failed: 400 Bad Request', 400, body);
+    assert.ok(err instanceof Error);
+    assert.equal(err.name, 'CompletionHttpError');
+    assert.equal(err.status, 400);
+    assert.equal(err.body, body);
+    assert.equal(err.message, 'Completion failed: 400 Bad Request');
   });
 });

--- a/src/__tests__/inlineCompletion.test.ts
+++ b/src/__tests__/inlineCompletion.test.ts
@@ -8,6 +8,7 @@ import {
   cleanCompletionText,
   extractCompletionText,
   extractFimContext,
+  isSuffixUnsupportedError,
   shouldRequestCompletion,
 } from '../inlineCompletion';
 
@@ -72,6 +73,60 @@ describe('buildCompletionRequestBody', () => {
       maxTokens: 64,
     });
     assert.equal('suffix' in req, false);
+  });
+
+  test('omits suffix when includeSuffix is false (server rejects the parameter)', () => {
+    const req = buildCompletionRequestBody({
+      model: 'm',
+      context: { prefix: 'tail', suffix: 'rest of file' },
+      maxTokens: 64,
+      includeSuffix: false,
+    });
+    assert.equal('suffix' in req, false);
+    assert.equal(req.prompt, 'tail');
+  });
+
+  test('keeps suffix when includeSuffix is explicitly true', () => {
+    const req = buildCompletionRequestBody({
+      model: 'm',
+      context: { prefix: 'tail', suffix: 'rest' },
+      maxTokens: 64,
+      includeSuffix: true,
+    });
+    assert.equal(req.suffix, 'rest');
+  });
+});
+
+describe('isSuffixUnsupportedError', () => {
+  test('matches the vLLM 400 response verbatim (issue #51)', () => {
+    const body =
+      '{"error":{"message":"suffix is not currently supported","type":"BadRequestError","param":null,"code":400}}';
+    assert.equal(isSuffixUnsupportedError(400, body), true);
+  });
+
+  test('matches wording variations that still name suffix as unsupported', () => {
+    assert.equal(
+      isSuffixUnsupportedError(400, '{"error":"the suffix parameter is not supported"}'),
+      true
+    );
+  });
+
+  test('ignores unrelated 400s', () => {
+    assert.equal(
+      isSuffixUnsupportedError(400, '{"error":{"message":"model not found"}}'),
+      false
+    );
+    assert.equal(
+      isSuffixUnsupportedError(400, '{"error":{"message":"context length exceeded"}}'),
+      false
+    );
+  });
+
+  test('ignores non-400 statuses even if the body mentions suffix', () => {
+    assert.equal(
+      isSuffixUnsupportedError(500, 'suffix is not currently supported'),
+      false
+    );
   });
 });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -164,6 +164,23 @@ export function describeFetchError(error: unknown): string {
   return error.message;
 }
 
+/**
+ * HTTP-level failure from `/v1/completions`. Carries the raw status and
+ * response body so callers can react to specific server limitations — e.g.
+ * vLLM's `400 "suffix is not currently supported"` — instead of string-matching
+ * the human-facing message.
+ */
+export class CompletionHttpError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: string
+  ) {
+    super(message);
+    this.name = 'CompletionHttpError';
+  }
+}
+
 export class GatewayClient {
   private config: GatewayConfig;
   private readonly log: GatewayLogger;
@@ -526,8 +543,10 @@ export class GatewayClient {
       const bodyText = await response.text().catch(() => '');
       const truncated = bodyText.length > 200 ? bodyText.slice(0, 200) + '...' : bodyText;
       const suffix = truncated ? ' — ' + truncated : '';
-      throw new Error(
-        `Completion failed: ${response.status} ${response.statusText}${suffix}`
+      throw new CompletionHttpError(
+        `Completion failed: ${response.status} ${response.statusText}${suffix}`,
+        response.status,
+        bodyText
       );
     }
     return await response.json();

--- a/src/inlineCompletion.ts
+++ b/src/inlineCompletion.ts
@@ -57,6 +57,13 @@ export interface CompletionRequestParams {
   model: string;
   context: FimContext;
   maxTokens: number;
+  /**
+   * When false, `suffix` is omitted even if the context has one. Fallback for
+   * servers whose `/v1/completions` rejects the parameter outright (vLLM
+   * returns `400 "suffix is not currently supported"` — issue #51); the model
+   * then plain-continues the prefix instead of filling in the middle.
+   */
+  includeSuffix?: boolean;
 }
 
 /**
@@ -74,10 +81,20 @@ export function buildCompletionRequestBody(
     temperature: COMPLETION_TEMPERATURE,
     stream: false,
   };
-  if (params.context.suffix.length > 0) {
+  if (params.includeSuffix !== false && params.context.suffix.length > 0) {
     request.suffix = params.context.suffix;
   }
   return request;
+}
+
+/**
+ * Whether a `/v1/completions` HTTP error means the server rejects the `suffix`
+ * parameter itself (as opposed to a transient or unrelated 400). vLLM answers
+ * `400 {"error":{"message":"suffix is not currently supported",...}}` for any
+ * request carrying `suffix`, regardless of the model's FIM ability.
+ */
+export function isSuffixUnsupportedError(status: number, body: string): boolean {
+  return status === 400 && /suffix\b[\s\S]{0,80}?not[\s\S]{0,40}?support/i.test(body);
 }
 
 /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,6 +1,11 @@
 import * as vscode from 'vscode';
-import { GatewayClient } from './client';
-import { GatewayConfig, OpenAIChatCompletionRequest, OpenAIMessage } from './types';
+import { CompletionHttpError, GatewayClient } from './client';
+import {
+  GatewayConfig,
+  OpenAIChatCompletionRequest,
+  OpenAICompletionRequest,
+  OpenAIMessage,
+} from './types';
 import {
   convertMessage,
   flattenToolResultContent,
@@ -25,6 +30,7 @@ import {
   cleanCompletionText,
   extractCompletionText,
   extractFimContext,
+  isSuffixUnsupportedError,
   shouldRequestCompletion,
 } from './inlineCompletion';
 import { InlineCompletionBackend } from './inlineCompletionProvider';
@@ -204,6 +210,12 @@ export class GatewayProvider
    */
   private modelFetchInFlight?: Promise<vscode.LanguageModelChatInformation[]>;
   private modelFetchLast?: { at: number; result: vscode.LanguageModelChatInformation[] };
+  /**
+   * Set once the server rejects the FIM `suffix` parameter (vLLM — issue #51).
+   * Subsequent completions go prefix-only instead of failing on every
+   * keystroke; cleared on config reload since the server may change.
+   */
+  private completionSuffixUnsupported = false;
   /** Tracks the last values we warned about, to avoid notification spam on each keystroke in the settings UI. */
   private lastInvalidUrlNotified?: string;
   private lastOutputTokenAdjustmentNotified?: { output: number; total: number };
@@ -863,17 +875,39 @@ export class GatewayProvider
       model,
       context,
       maxTokens: this.config.inlineCompletionMaxTokens,
+      includeSuffix: !this.completionSuffixUnsupported,
     });
 
     try {
-      const response = await this.client.fetchCompletion(
-        request,
-        token,
-        this.config.inlineCompletionTimeout
-      );
-      const text = cleanCompletionText(extractCompletionText(response));
-      return text.length > 0 ? text : undefined;
+      return await this.fetchInlineCompletionText(request, token);
     } catch (error) {
+      if (
+        request.suffix !== undefined &&
+        error instanceof CompletionHttpError &&
+        isSuffixUnsupportedError(error.status, error.body)
+      ) {
+        this.completionSuffixUnsupported = true;
+        this.outputChannel.appendLine(
+          'Inline completion: server rejected the FIM "suffix" parameter (vLLM does not implement it). ' +
+            'Falling back to prefix-only completions — the text after the cursor will be ignored.'
+        );
+        try {
+          return await this.fetchInlineCompletionText(
+            buildCompletionRequestBody({
+              model,
+              context,
+              maxTokens: this.config.inlineCompletionMaxTokens,
+              includeSuffix: false,
+            }),
+            token
+          );
+        } catch (retryError) {
+          this.outputChannel.appendLine(
+            `Inline completion failed: ${retryError instanceof Error ? retryError.message : String(retryError)}`
+          );
+          return undefined;
+        }
+      }
       // Completions are best-effort: a failure should silently yield no
       // suggestion rather than surfacing a toast on every keystroke.
       this.outputChannel.appendLine(
@@ -881,6 +915,20 @@ export class GatewayProvider
       );
       return undefined;
     }
+  }
+
+  /** Fire one `/v1/completions` request and normalise the result to ghost text. */
+  private async fetchInlineCompletionText(
+    request: OpenAICompletionRequest,
+    token: vscode.CancellationToken
+  ): Promise<string | undefined> {
+    const response = await this.client.fetchCompletion(
+      request,
+      token,
+      this.config.inlineCompletionTimeout
+    );
+    const text = cleanCompletionText(extractCompletionText(response));
+    return text.length > 0 ? text : undefined;
   }
 
   /**
@@ -1384,6 +1432,8 @@ export class GatewayProvider
   private reloadConfig(): void {
     this.config = this.loadConfig();
     this.client.updateConfig(this.config);
+    // The server (or its capabilities) may have changed — probe suffix support again.
+    this.completionSuffixUnsupported = false;
     this.outputChannel.appendLine('Configuration reloaded');
   }
 }


### PR DESCRIPTION
* fix: fall back to prefix-only completions when server rejects FIM suffix (#51)

vLLM's OpenAI-compatible /v1/completions endpoint rejects the suffix parameter unconditionally (400 "suffix is not currently supported"), which made inline completions fail on every keystroke against vLLM.

- fetchCompletion now throws a typed CompletionHttpError carrying the HTTP status and raw body so callers can react to specific server limitations instead of string-matching the formatted message
- detect the suffix-unsupported 400, retry once without suffix, and remember it for the session so later completions go prefix-only without doubled requests; flag resets on config reload
- document the fallback in the README and correct the claim that vLLM supports the suffix parameter

* chore: bump version to 1.3.0