### PR TITLE
fix: strip internal telemetry parameters starting with underscore from requests

### DIFF
--- a/src/api/__tests__/requestBuilder.test.ts
+++ b/src/api/__tests__/requestBuilder.test.ts
@@ -118,4 +118,23 @@ describe('buildChatRequest', () => {
     });
     assert.equal(req.tool_choice, 'none');
   });
+
+  test('strips extraOptions keys starting with underscore', () => {
+    const req = buildChatRequest({
+      model: 'm',
+      messages: [],
+      maxTokens: 10,
+      temperature: 0.5,
+      extraOptions: {
+        top_p: 0.9,
+        _otelTraceContext: 'some-trace-id',
+        _telemetryTurn: 'some-turn-id',
+        _capturingTokenCorrelationId: 'some-correlation-id',
+      },
+    });
+    assert.equal(req.top_p, 0.9);
+    assert.equal((req as any)._otelTraceContext, undefined);
+    assert.equal((req as any)._telemetryTurn, undefined);
+    assert.equal((req as any)._capturingTokenCorrelationId, undefined);
+  });
 });

--- a/src/api/requestBuilder.ts
+++ b/src/api/requestBuilder.ts
@@ -48,7 +48,11 @@ export function buildChatRequest(options: ChatRequestOptions): OpenAIChatComplet
   }
 
   if (options.extraOptions) {
-    Object.assign(request, options.extraOptions);
+    for (const [key, value] of Object.entries(options.extraOptions)) {
+      if (!key.startsWith('_')) {
+        (request as any)[key] = value;
+      }
+    }
   }
 
   return request;


### PR DESCRIPTION
This PR strips internal VS Code / Copilot telemetry/tracing parameters (keys starting with an underscore like `_otelTraceContext`, `_telemetryTurn`, `_capturingTokenCorrelationId`) from the final completions request body. Strict upstream APIs (like Azure OpenAI) reject requests containing these unknown parameters with a 400 Bad Request error.