### PR TITLE
Feature/status popup polish

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "github-copilot-llm-gateway",
   "displayName": "GitHub Copilot LLM Gateway",
   "description": "Connect GitHub Copilot to open-source models via vLLM or any OpenAI-compatible server",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "publisher": "AndrewButson",
   "icon": "assets/copilot-llm-gateway.png",
   "private": true,

--- a/src/provider/gatewayProvider.ts
+++ b/src/provider/gatewayProvider.ts
@@ -421,6 +421,8 @@ export class GatewayProvider
         toolCalling: this.config.enableToolCalling,
         imageInput: this.config.enableImageInput,
         parallelToolCalling: this.config.parallelToolCalling,
+        inlineCompletion: this.config.enableInlineCompletion,
+        inlineCompletionModel: this.config.inlineCompletionModel,
         agentTemperature: this.config.agentTemperature,
       },
       now: Date.now(),

--- a/src/status/__tests__/statusTooltip.test.ts
+++ b/src/status/__tests__/statusTooltip.test.ts
@@ -29,6 +29,8 @@ function makeSnapshot(overrides: Partial<StatusSnapshot> = {}): StatusSnapshot {
       toolCalling: true,
       imageInput: true,
       parallelToolCalling: true,
+      inlineCompletion: false,
+      inlineCompletionModel: '',
       agentTemperature: 0,
     },
     now: FIXED_NOW,
@@ -96,6 +98,8 @@ describe('renderStatusTooltipHtml — sanitizer conformance', () => {
           toolCalling: true,
           imageInput: false,
           parallelToolCalling: false,
+          inlineCompletion: true,
+          inlineCompletionModel: 'starcoder2-3b',
           agentTemperature: 0.7,
         },
       })
@@ -160,7 +164,7 @@ describe('renderStatusTooltipHtml — connection row', () => {
     assert.ok(html.includes('Last refresh: 2m ago'));
   });
 
-  test('renders "Disconnected" + escaped error in a <pre> block for error state', () => {
+  test('renders "Disconnected" + escaped error as wrapping text (not <pre>)', () => {
     const html = renderStatusTooltipHtml(
       makeSnapshot({
         connection: { state: 'error', errorMessage: 'ECONNREFUSED <bad>' },
@@ -169,7 +173,21 @@ describe('renderStatusTooltipHtml — connection row', () => {
     );
     assert.ok(html.includes('$(error)'));
     assert.ok(html.includes('Disconnected'));
-    assert.ok(html.includes('<pre>ECONNREFUSED &lt;bad&gt;</pre>'));
+    // <pre> would keep long messages on one unwrapped line that overflows the
+    // popup — the error must render as normal wrapping text instead.
+    assert.ok(!html.includes('<pre>'));
+    assert.ok(html.includes('ECONNREFUSED &lt;bad&gt;'));
+    assert.ok(!html.includes('Last success:'));
+  });
+
+  test('shows how stale the cached models are when disconnected after a prior success', () => {
+    const html = renderStatusTooltipHtml(
+      makeSnapshot({
+        connection: { state: 'error', errorMessage: 'ECONNREFUSED' },
+        lastSuccessfulFetchAt: FIXED_NOW - 300_000,
+      })
+    );
+    assert.ok(html.includes('Last success: 5m ago'));
   });
 
   test('renders "Connected · empty" with warning for noModels', () => {
@@ -410,13 +428,60 @@ describe('renderStatusTooltipHtml — feature rows', () => {
           toolCalling: true,
           imageInput: false,
           parallelToolCalling: false,
+          inlineCompletion: false,
+          inlineCompletionModel: '',
           agentTemperature: 0.7,
         },
       })
     );
     assert.ok(html.includes('<span style="color:var(--vscode-charts-green);">Enabled</span>'));
     assert.ok(/<span style="color:var\(--vscode-descriptionForeground\);">Disabled<\/span>/.test(html));
-    assert.ok(html.includes('temp 0.7'));
+  });
+
+  test('renders agent temperature as its own value row, not a suffix on another feature', () => {
+    const html = renderStatusTooltipHtml(makeSnapshot());
+    assert.ok(html.includes('Agent temperature'));
+    assert.ok(html.includes('0.0'));
+    assert.ok(!html.includes('· temp'), 'temperature must not ride along on the parallel-tool-calls row');
+  });
+
+  test('shows the inline-completion model next to the label when enabled', () => {
+    const html = renderStatusTooltipHtml(
+      makeSnapshot({
+        features: {
+          toolCalling: true,
+          imageInput: true,
+          parallelToolCalling: true,
+          inlineCompletion: true,
+          inlineCompletionModel: 'starcoder2-3b',
+          agentTemperature: 0,
+        },
+      })
+    );
+    assert.ok(html.includes('Inline completion'));
+    assert.ok(html.includes('starcoder2-3b'));
+  });
+
+  test('falls back to "first server model" when inline completion is enabled with no model set', () => {
+    const html = renderStatusTooltipHtml(
+      makeSnapshot({
+        features: {
+          toolCalling: true,
+          imageInput: true,
+          parallelToolCalling: true,
+          inlineCompletion: true,
+          inlineCompletionModel: '',
+          agentTemperature: 0,
+        },
+      })
+    );
+    assert.ok(html.includes('first server model'));
+  });
+
+  test('omits the model detail when inline completion is disabled', () => {
+    const html = renderStatusTooltipHtml(makeSnapshot());
+    assert.ok(html.includes('Inline completion'));
+    assert.ok(!html.includes('first server model'));
   });
 });
 

--- a/src/status/statusSnapshot.ts
+++ b/src/status/statusSnapshot.ts
@@ -31,6 +31,9 @@ export interface FeatureFlags {
   readonly toolCalling: boolean;
   readonly imageInput: boolean;
   readonly parallelToolCalling: boolean;
+  readonly inlineCompletion: boolean;
+  /** Model id for inline completions; `''` means "first model from the server". */
+  readonly inlineCompletionModel: string;
   readonly agentTemperature: number;
 }
 

--- a/src/status/statusTooltip.ts
+++ b/src/status/statusTooltip.ts
@@ -114,9 +114,12 @@ function renderHeader(snapshot: StatusSnapshot): string {
 
 function renderConnection(snapshot: StatusSnapshot): string {
   const desc = describeConnection(snapshot);
+  // Plain <div> text rather than <pre>: the hover widget wraps normal text at
+  // its max-width, while <pre> keeps long messages (URLs, stack fragments) on
+  // one unbroken line that overflows the popup.
   const errorRow =
     snapshot.connection.state === 'error' && snapshot.connection.errorMessage
-      ? `\n\n<pre>${esc(snapshot.connection.errorMessage)}</pre>`
+      ? `\n\n<div>${mutedSpan(esc(snapshot.connection.errorMessage))}</div>`
       : '';
   return [
     '\n<hr>\n',
@@ -161,7 +164,11 @@ function describeConnection(snapshot: StatusSnapshot): ConnectionDescriptor {
       return {
         icon: '$(error)',
         label: 'Disconnected',
-        sideText: '',
+        // When we still hold a stale model list, say how old it is — useful
+        // for judging whether the cached models are trustworthy.
+        sideText: snapshot.lastSuccessfulFetchAt
+          ? `Last success: ${formatRelativeTime(snapshot.lastSuccessfulFetchAt, snapshot.now)}`
+          : '',
         color: '-errorForeground',
       };
     case 'unknown':
@@ -324,14 +331,15 @@ function capabilityPill(label: string): string {
 
 function renderFeatures(snapshot: StatusSnapshot): string {
   const f = snapshot.features;
+  const inlineModel = f.inlineCompletion
+    ? f.inlineCompletionModel || 'first server model'
+    : '';
   const featureRows = [
     featureRow('Tool calling', f.toolCalling),
     featureRow('Image input', f.imageInput),
-    featureRow(
-      'Parallel tool calls',
-      f.parallelToolCalling,
-      ` · temp ${f.agentTemperature.toFixed(1)}`
-    ),
+    featureRow('Parallel tool calls', f.parallelToolCalling),
+    featureRow('Inline completion', f.inlineCompletion, inlineModel),
+    valueRow('$(dashboard)', 'Agent temperature', f.agentTemperature.toFixed(1)),
   ].join('');
   return [
     '\n<hr>\n',
@@ -340,13 +348,24 @@ function renderFeatures(snapshot: StatusSnapshot): string {
   ].join('');
 }
 
-function featureRow(label: string, enabled: boolean, suffix = ''): string {
+/**
+ * Boolean feature row: `$(check) Label … Enabled`. `detail` is extra muted
+ * context appended after the label (e.g. the inline-completion model) so the
+ * right-hand Enabled/Disabled column stays aligned across all rows.
+ */
+function featureRow(label: string, enabled: boolean, detail = ''): string {
   const icon = enabled ? '$(check)' : '$(circle-slash)';
   const statusLabel = enabled ? 'Enabled' : 'Disabled';
   const status = enabled
     ? `<span style="color:var(--vscode-charts-green);">${statusLabel}</span>`
     : mutedSpan(statusLabel);
-  return `<tr><td>${icon}&nbsp;${esc(label)}</td><td align="right">${status}${esc(suffix)}</td></tr>`;
+  const detailText = detail ? `&nbsp;${mutedSpan(esc(detail))}` : '';
+  return `<tr><td>${icon}&nbsp;${esc(label)}${detailText}</td><td align="right">${status}</td></tr>`;
+}
+
+/** Setting-value row: `$(icon) Label … value` with the value muted, not green. */
+function valueRow(icon: string, label: string, value: string): string {
+  return `<tr><td>${icon}&nbsp;${esc(label)}</td><td align="right">${mutedSpan(esc(value))}</td></tr>`;
 }
 
 function renderFooter(): string {


### PR DESCRIPTION
Status popup polish

Improves the status bar hover popup with better layout, more information, and fixes for long error messages. Also bumps the version to 1.6.0.

Changes

Aligned feature rows
- The Enabled/Disabled column now stays right-aligned across all rows. Extra context (like the inline-completion model) is rendered as muted text after the label instead of being appended to the status column.
- Agent temperature moved out of the "Parallel tool calls" row into its own setting-value row ($(dashboard) Agent temperature · 0.0), rendered muted rather than green since it's a value, not an on/off state.

New information in the popup
- Inline completion now appears as a feature row, showing the configured model (or "first server model" when inlineCompletionModel is blank). FeatureFlags gains inlineCompletion and inlineCompletionModel, populated from the provider config.
- When disconnected but still holding a cached model list, the connection row shows how stale it is ("Last success: 5m ago") so users can judge whether the cached models are trustworthy.

Error message wrapping
- Connection errors are rendered as plain muted text instead of `pre`. The hover widget wraps normal text at its max-width, while kept long messages (URLs, stack fragments) on one unbroken line that overflowed the popup.