### PR TITLE
Expand suffix error detection to catch LiteLLM errors

### DIFF
--- a/src/completions/__tests__/inlineCompletion.test.ts
+++ b/src/completions/__tests__/inlineCompletion.test.ts
@@ -111,6 +111,30 @@ describe('isSuffixUnsupportedError', () => {
     );
   });
 
+  test('matches LiteLLM "Extra inputs are not permitted" error for suffix verbatim (issue #68)', () => {
+    const litellmError =
+      '{"error":{"message":"litellm.BadRequestError: OpenAIException - {\"message\":\"The model returned the following errors: suffix: Extra inputs are not permitted\"}.';
+    assert.equal(isSuffixUnsupportedError(400, litellmError), true);
+  });
+
+  test('matches wording variations that still name suffix as not permitted"', () => {
+    assert.equal(
+      isSuffixUnsupportedError(400, 'suffix is not permitted'),
+      true
+    );
+    assert.equal(
+      isSuffixUnsupportedError(400, 'the suffix parameter is not permitted'),
+      true
+    );
+  });
+
+  test('ignores "not permitted" error when it does not mention suffix', () => {
+    assert.equal(
+      isSuffixUnsupportedError(400, 'extra inputs are not permitted'),
+      false
+    );
+  });
+
   test('ignores unrelated 400s', () => {
     assert.equal(
       isSuffixUnsupportedError(400, '{"error":{"message":"model not found"}}'),

--- a/src/completions/inlineCompletion.ts
+++ b/src/completions/inlineCompletion.ts
@@ -66,7 +66,7 @@ export interface CompletionRequestParams {
   /**
    * When false, `suffix` is omitted even if the context has one. Fallback for
    * servers whose `/v1/completions` rejects the parameter outright (vLLM
-   * returns `400 "suffix is not currently supported"` — issue #51); the model
+   * returns `400 "suffix is not currently supported"` — issue #51, LiteLLM — issue #68); the model
    * then plain-continues the prefix instead of filling in the middle.
    */
   includeSuffix?: boolean;
@@ -97,10 +97,12 @@ export function buildCompletionRequestBody(
  * Whether a `/v1/completions` HTTP error means the server rejects the `suffix`
  * parameter itself (as opposed to a transient or unrelated 400). vLLM answers
  * `400 {"error":{"message":"suffix is not currently supported",...}}` for any
- * request carrying `suffix`, regardless of the model's FIM ability.
+ * request carrying `suffix`, regardless of the model's FIM ability. LiteLLM
+ * answers `400 "suffix: Extra inputs are not permitted"` when the underlying
+ * model doesn't accept the parameter.
  */
 export function isSuffixUnsupportedError(status: number, body: string): boolean {
-  return status === 400 && /suffix\b[\s\S]{0,80}?not[\s\S]{0,40}?support/i.test(body);
+  return status === 400 && /suffix\b[\s\S]{0,80}?not[\s\S]{0,40}?(?:support|permit)/i.test(body);
 }
 
 /**

--- a/src/provider/inlineCompletionService.ts
+++ b/src/provider/inlineCompletionService.ts
@@ -23,11 +23,11 @@ interface InlineCompletionServiceDeps {
  * Orchestrates fill-in-the-middle completions against `/v1/completions`.
  * This runs alongside (not through) Copilot, which doesn't expose BYOK
  * models to its own inline suggestions (issue #44). Owns the
- * suffix-unsupported fallback state (vLLM — issue #51).
+ * suffix-unsupported fallback state (vLLM — issue #51, LiteLLM — issue #68).
  */
 export class InlineCompletionService {
   /**
-   * Set once the server rejects the FIM `suffix` parameter (vLLM — issue #51).
+   * Set once the server rejects the FIM `suffix` parameter (vLLM — issue #51, LiteLLM — issue #68).
    * Subsequent completions go prefix-only instead of failing on every
    * keystroke; cleared on config reload since the server may change.
    */


### PR DESCRIPTION
This PR fixes an issue where the extension's inline completion feature would fail repeatedly when using LiteLLM with models that don't support the `suffix` parameter. The extension already had automatic fallback logic for vLLM's "suffix is not currently supported" error, but LiteLLM returns a different error message format that wasn't being detected.

## Changes

Expanded the error detection pattern in `isSuffixUnsupportedError()` to catch both error formats:
- **vLLM**: `"suffix is not currently supported"`
- **LiteLLM**: `"suffix: Extra inputs are not permitted"`

The combined regex pattern `suffix...not...(?:support|permit)` now matches variations like:
- "suffix is not permitted"
- "suffix: Extra inputs are not permitted" 
- "the suffix parameter is not permitted"
- "suffix is not currently supported"

When either error is detected, the extension automatically:
1. Logs a helpful message about the fallback
2. Retries the request without the suffix parameter
3. Remembers the fallback state for all future inline completion requests

## Testing

- Added test coverage for LiteLLM error format
- Added tests for permissive pattern variations
- Added test to ensure unrelated "not permitted" errors are ignored
- All 402 tests pass

## Resoultion

This PR Resolves Issue #68 