### PR TITLE
fix: truncation gate ignored input overhead ratio, collapsing max_tokens to 64

### DIFF
--- a/src/chat/__tests__/tokenBudget.test.ts
+++ b/src/chat/__tests__/tokenBudget.test.ts
@@ -186,8 +186,8 @@ describe('calculateMaxInputTokens', () => {
       toolsSerializedLength: 0,
     });
     // desiredOutput = min(8000, 5000) = 5000
-    // Expected = 10000 - 5000 - 0 - 256 = 4744
-    assert.equal(result, 4744);
+    // Expected = floor((10000 - 5000 - 256) / 1.2) = 3953
+    assert.equal(result, 3953);
   });
 
   test('reserves configured output when less than half context', () => {
@@ -196,8 +196,8 @@ describe('calculateMaxInputTokens', () => {
       configuredMaxOutput: 2048,
       toolsSerializedLength: 0,
     });
-    // desiredOutput = 2048; expected = 32768 - 2048 - 0 - 256 = 30464
-    assert.equal(result, 30464);
+    // desiredOutput = 2048; expected = floor((32768 - 2048 - 256) / 1.2) = 25386
+    assert.equal(result, 25386);
   });
 
   test('subtracts tools overhead', () => {
@@ -212,5 +212,41 @@ describe('calculateMaxInputTokens', () => {
       toolsSerializedLength: 4000,
     });
     assert.ok(withTools < baseline);
+  });
+
+  test('never returns a negative ceiling', () => {
+    const result = calculateMaxInputTokens({
+      modelMaxContext: 4096,
+      configuredMaxOutput: 2048,
+      toolsSerializedLength: 100000,
+    });
+    assert.equal(result, 0);
+  });
+
+  test('input at the ceiling still leaves room for the desired output (issue #74)', () => {
+    // Reproduces issue #74: 163840-token context, ~27K tokens of tools,
+    // long conversation. Previously the truncation gate ignored the 1.2x
+    // overhead ratio on message input, so ~117K input tokens passed
+    // untruncated, then calculateSafeMaxOutputTokens inflated the same
+    // tokens by 1.2x, overflowed the context, and clamped max_tokens to 64.
+    const modelMaxContext = 163840;
+    const configuredMaxOutput = 4096;
+    const toolsSerializedLength = 27431 * TOKEN_CONSTANTS.CHARS_PER_TOKEN;
+
+    const maxInput = calculateMaxInputTokens({
+      modelMaxContext,
+      configuredMaxOutput,
+      toolsSerializedLength,
+    });
+
+    // Simulate a conversation truncated to exactly the input ceiling.
+    const safeOutput = calculateSafeMaxOutputTokens({
+      estimatedInputTokens: maxInput,
+      toolsOverhead: Math.ceil(toolsSerializedLength / TOKEN_CONSTANTS.CHARS_PER_TOKEN),
+      modelMaxContext,
+      configuredMaxOutput,
+    });
+
+    assert.equal(safeOutput, configuredMaxOutput);
   });
 });

--- a/src/chat/tokenBudget.ts
+++ b/src/chat/tokenBudget.ts
@@ -155,15 +155,26 @@ export interface MaxInputTokensParams {
 /**
  * Compute the ceiling on input tokens for a request so there's still room
  * for output + tools in the context window.
+ *
+ * Must stay the exact inverse of {@link calculateSafeMaxOutputTokens}: that
+ * function inflates (input + tools) by INPUT_OVERHEAD_RATIO, so the ceiling
+ * here divides the available budget by the same ratio before subtracting the
+ * raw tools estimate. If the two drift apart, a conversation can pass the
+ * truncation gate yet leave "no room" for output, collapsing max_tokens to
+ * MIN_OUTPUT_TOKENS (issue #74).
  */
 export function calculateMaxInputTokens(params: MaxInputTokensParams): number {
   const desiredOutputTokens = Math.min(
     params.configuredMaxOutput,
     Math.floor(params.modelMaxContext / 2)
   );
-  const toolsTokenEstimate = Math.ceil(
-    (params.toolsSerializedLength / TOKEN_CONSTANTS.CHARS_PER_TOKEN) *
-      TOKEN_CONSTANTS.INPUT_OVERHEAD_RATIO
+  const toolsRawEstimate = Math.ceil(
+    params.toolsSerializedLength / TOKEN_CONSTANTS.CHARS_PER_TOKEN
   );
-  return params.modelMaxContext - desiredOutputTokens - toolsTokenEstimate - TOKEN_CONSTANTS.CONTEXT_BUFFER_TOKENS;
+  const inputBudget =
+    params.modelMaxContext - desiredOutputTokens - TOKEN_CONSTANTS.CONTEXT_BUFFER_TOKENS;
+  return Math.max(
+    0,
+    Math.floor(inputBudget / TOKEN_CONSTANTS.INPUT_OVERHEAD_RATIO) - toolsRawEstimate
+  );
 }

--- a/src/provider/chatRequestHandler.ts
+++ b/src/provider/chatRequestHandler.ts
@@ -207,6 +207,11 @@ export class ChatRequestHandler {
       log(
         `Token estimate: input=${estimatedInputTokens}, tools=${toolsOverhead}, model_context=${modelMaxContext}, chosen_max_tokens=${safeMaxOutputTokens}`
       );
+      if (safeMaxOutputTokens <= TOKEN_CONSTANTS.MIN_OUTPUT_TOKENS) {
+        log(
+          `WARNING: max_tokens clamped to floor (${safeMaxOutputTokens}); input does not fit the context window even after truncation — responses will be cut off`
+        );
+      }
 
       const hasTools = filteredTools !== undefined && filteredTools.length > 0;
 


### PR DESCRIPTION
calculateMaxInputTokens applied the 1.2x INPUT_OVERHEAD_RATIO only to the tools estimate, while calculateSafeMaxOutputTokens inflates input + tools combined. A long conversation could pass the truncation gate untouched, then overflow the context in the output calculation and clamp max_tokens to MIN_OUTPUT_TOKENS (64), truncating every response.

Make calculateMaxInputTokens the exact inverse of the output formula: divide the post-output budget by the overhead ratio before subtracting the raw tools estimate, and clamp the ceiling at zero. Also warn in the request log when max_tokens hits the floor, since that now only happens when input cannot fit even after truncation.

Fixes #74