### PR TITLE
Add LiteLLM model token limit discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Configure the extension through VS Code Settings (`Ctrl+,` / `Cmd+,`) → search
 | Setting                       | Default  | Description                                                                                                  |
 | ----------------------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
 | **Default Max Tokens**        | `262144` | Fallback context window size (input tokens) used only when the inference server does not report one itself.  |
-| **Default Max Output Tokens** | `4096`   | Fallback maximum output tokens used only when the server does not report a context size.                     |
+| **Default Max Output Tokens** | `4096`   | Fallback maximum output tokens used when the server does not report `max_output_tokens`.                     |
 | **Model Context Windows**     | `{}`     | Per-model context window override (total tokens), keyed by model id or `*` wildcard. Wins over server-reported values. |
 | **Enable Image Input**        | `true`   | Advertise image-input capability for multimodal models and forward image parts as base64 `image_url`s.       |
 
@@ -193,7 +193,7 @@ Configure the extension through VS Code Settings (`Ctrl+,` / `Cmd+,`) → search
 For each model the gateway uses, in priority order:
 
 1. **Your `modelContextWindows` override**, if one matches the model id (exactly or via a `*` wildcard — same matching rules as `perModelOptions`).
-2. **What the server reports** in `/v1/models`: `max_model_len` (vLLM, LiteLLM), `context_length` (Ollama, LocalAI, LM Studio), `context_window`, or llama.cpp's `meta.n_ctx` / `meta.n_ctx_train`.
+2. **What the server reports** in `/v1/models`: `max_model_len` (vLLM), `max_input_tokens` (LiteLLM), `context_length` (Ollama, LocalAI, LM Studio), `context_window`, or llama.cpp's `meta.n_ctx` / `meta.n_ctx_train`. LiteLLM's separate `max_output_tokens` is also used as the model's output ceiling.
 3. **`defaultMaxTokens`** as the last resort.
 
 Some servers can't report a size up-front — llama-server in **router mode**, for example, only includes context metadata for models that are currently loaded. If a request then overflows, the gateway parses the server's context-overflow error, learns the real limit for that model, and transparently retries the request once (when nothing has been streamed yet). Learned limits last for the session; add the model to `modelContextWindows` to persist them:

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
         "github.copilot.llm-gateway.defaultMaxOutputTokens": {
           "type": "number",
           "default": 4096,
-          "description": "Fallback maximum output tokens when the server does not report context size",
+          "description": "Fallback maximum output tokens when the server does not report max_output_tokens",
           "order": 5
         },
         "github.copilot.llm-gateway.enableImageInput": {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -9,6 +9,10 @@ export interface OpenAIModel {
   owned_by: string;
   /** vLLM, LiteLLM */
   max_model_len?: number;
+  /** LiteLLM: maximum prompt/context tokens accepted by the model. */
+  max_input_tokens?: number;
+  /** LiteLLM: maximum completion tokens the model can generate. */
+  max_output_tokens?: number;
   /** Ollama, LocalAI, LM Studio */
   context_length?: number;
   /** llama.cpp */

--- a/src/chat/__tests__/contextWindow.test.ts
+++ b/src/chat/__tests__/contextWindow.test.ts
@@ -4,6 +4,7 @@ import {
   parseContextOverflowError,
   resolveContextWindowOverride,
   serverReportedContext,
+  serverReportedMaxOutput,
 } from '../contextWindow';
 import { OpenAIModel } from '../../api/types';
 
@@ -33,6 +34,11 @@ describe('serverReportedContext', () => {
     assert.equal(serverReportedContext(model), 123904);
   });
 
+  test('reads LiteLLM max_input_tokens when max_model_len is absent', () => {
+    const model = baseModel({ max_input_tokens: 300000, max_output_tokens: 10000 });
+    assert.equal(serverReportedContext(model), 300000);
+  });
+
   test('falls back to meta.n_ctx_train when n_ctx is absent', () => {
     const model = baseModel({ meta: { n_ctx_train: 32768 } });
     assert.equal(serverReportedContext(model), 32768);
@@ -50,6 +56,18 @@ describe('serverReportedContext', () => {
       meta: { n_ctx: 4096 },
     });
     assert.equal(serverReportedContext(model), 4096);
+  });
+});
+
+describe('serverReportedMaxOutput', () => {
+  test('reads LiteLLM max_output_tokens', () => {
+    assert.equal(serverReportedMaxOutput(baseModel({ max_output_tokens: 64000 })), 64000);
+  });
+
+  test('ignores absent and unusable values', () => {
+    assert.equal(serverReportedMaxOutput(baseModel()), undefined);
+    assert.equal(serverReportedMaxOutput(baseModel({ max_output_tokens: 0 })), undefined);
+    assert.equal(serverReportedMaxOutput(baseModel({ max_output_tokens: -1 })), undefined);
   });
 });
 

--- a/src/chat/contextWindow.ts
+++ b/src/chat/contextWindow.ts
@@ -30,12 +30,18 @@ function isUsableContext(value: unknown): value is number {
 export function serverReportedContext(model: OpenAIModel): number | undefined {
   const candidates = [
     model.max_model_len, // vLLM, LiteLLM
+    model.max_input_tokens, // LiteLLM
     model.context_length, // Ollama, LocalAI, LM Studio
     model.context_window, // llama.cpp (older builds)
     model.meta?.n_ctx, // llama.cpp serving context
     model.meta?.n_ctx_train, // llama.cpp training context
   ];
   return candidates.find(isUsableContext);
+}
+
+/** Extract a model's independently reported completion-token ceiling. */
+export function serverReportedMaxOutput(model: OpenAIModel): number | undefined {
+  return isUsableContext(model.max_output_tokens) ? model.max_output_tokens : undefined;
 }
 
 /**

--- a/src/models/__tests__/modelInfoBuilder.test.ts
+++ b/src/models/__tests__/modelInfoBuilder.test.ts
@@ -114,6 +114,19 @@ describe('buildModelInfo context resolution', () => {
     assert.equal(hasServerReportedContext, true);
   });
 
+  test('uses LiteLLM max_input_tokens and max_output_tokens', () => {
+    const { totalContext, info, hasServerReportedContext } = buildModelInfo({
+      model: baseModel({ max_input_tokens: 300000, max_output_tokens: 10000 }),
+      defaultMaxTokens: 9999,
+      defaultMaxOutputTokens: 2048,
+      capabilities: {},
+    });
+    assert.equal(totalContext, 300000);
+    assert.equal(info.maxInputTokens, 300000);
+    assert.equal(info.maxOutputTokens, 10000);
+    assert.equal(hasServerReportedContext, true);
+  });
+
   test('falls back to context_window when max_model_len and context_length are absent', () => {
     const { totalContext, hasServerReportedContext } = buildModelInfo({
       model: baseModel({ context_window: 4096 }),
@@ -182,6 +195,17 @@ describe('buildModelInfo output token math', () => {
       capabilities: {},
     });
     assert.equal(info.maxOutputTokens, 2048);
+  });
+
+  test('clamps a LiteLLM output limit to the available context headroom', () => {
+    const totalContext = 8192;
+    const { info } = buildModelInfo({
+      model: baseModel({ max_input_tokens: totalContext, max_output_tokens: totalContext }),
+      defaultMaxTokens: 32768,
+      defaultMaxOutputTokens: 2048,
+      capabilities: {},
+    });
+    assert.equal(info.maxOutputTokens, totalContext - TOKEN_CONSTANTS.ADJUST_TOKEN_BUFFER);
   });
 
   test('reduces maxOutputTokens to leave the ADJUST_TOKEN_BUFFER headroom when the window is tight', () => {

--- a/src/models/modelInfoBuilder.ts
+++ b/src/models/modelInfoBuilder.ts
@@ -7,7 +7,7 @@
 
 import { OpenAIModel } from '../api/types';
 import { describeModel, friendlyModelName, inferModelFamily } from './modelDisplay';
-import { serverReportedContext } from '../chat/contextWindow';
+import { serverReportedContext, serverReportedMaxOutput } from '../chat/contextWindow';
 import { TOKEN_CONSTANTS } from '../chat/tokenBudget';
 
 /**
@@ -76,7 +76,9 @@ export interface BuildModelInfoResult {
  *
  * `maxInputTokens` is intentionally set to the full server-reported context so
  * the picker shows the true window size. Output-token budgeting uses
- * `totalContext` separately so the math doesn't double-count.
+ * `totalContext` separately so the math doesn't double-count. When LiteLLM
+ * reports `max_output_tokens`, that model-specific ceiling replaces the
+ * configured fallback.
  */
 export function buildModelInfo({
   model,
@@ -87,10 +89,11 @@ export function buildModelInfo({
   discoveredContext,
 }: BuildModelInfoInput): BuildModelInfoResult {
   const serverContext = serverReportedContext(model);
+  const serverMaxOutput = serverReportedMaxOutput(model);
   const totalContext =
     contextOverride ?? discoveredContext ?? serverContext ?? defaultMaxTokens;
   const maxOutputTokens = Math.min(
-    defaultMaxOutputTokens,
+    serverMaxOutput ?? defaultMaxOutputTokens,
     Math.max(
       TOKEN_CONSTANTS.MIN_OUTPUT_TOKENS,
       totalContext - TOKEN_CONSTANTS.ADJUST_TOKEN_BUFFER


### PR DESCRIPTION
Used Codex to makes these changes since our LiteLLM instance was reporting max_input_tokens and max_output_tokens instead of max_model_len and that was causing all discovered models to fall back to the defaults. 