### PR TITLE
fix: double-counted output reservation for LiteLLM separate token windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,10 @@ Configure the extension through VS Code Settings (`Ctrl+,` / `Cmd+,`) → search
 For each model the gateway uses, in priority order:
 
 1. **Your `modelContextWindows` override**, if one matches the model id (exactly or via a `*` wildcard — same matching rules as `perModelOptions`).
-2. **What the server reports** in `/v1/models`: `max_model_len` (vLLM), `max_input_tokens` (LiteLLM), `context_length` (Ollama, LocalAI, LM Studio), `context_window`, or llama.cpp's `meta.n_ctx` / `meta.n_ctx_train`. LiteLLM's separate `max_output_tokens` is also used as the model's output ceiling.
+2. **What the server reports** in `/v1/models`: `max_model_len` (vLLM, and LiteLLM when it fronts one), `max_input_tokens` (LiteLLM), `context_length` (Ollama, LocalAI, LM Studio), `context_window`, or llama.cpp's `meta.n_ctx` / `meta.n_ctx_train`. LiteLLM's separate `max_output_tokens` is also used as the model's output ceiling.
 3. **`defaultMaxTokens`** as the last resort.
+
+Most servers report one **shared** window that the prompt and the completion both come out of (vLLM's `max_model_len`, llama.cpp's `n_ctx`, Ollama's `context_length`), so the gateway reserves room for output before deciding how much conversation fits. LiteLLM is the exception: its `max_input_tokens` is a prompt-only ceiling with `max_output_tokens` as a **separate** allowance, so a model advertised as 200K in / 64K out gets the full 200K for the prompt rather than 136K. The gateway only treats the two as separate when `max_model_len` is absent and the output ceiling is genuinely smaller than the input one — anything else is budgeted as a single shared window, and a context-overflow error from the server flips a model back to shared for the rest of the session.
 
 Some servers can't report a size up-front — llama-server in **router mode**, for example, only includes context metadata for models that are currently loaded. If a request then overflows, the gateway parses the server's context-overflow error, learns the real limit for that model, and transparently retries the request once (when nothing has been streamed yet). Learned limits last for the session; add the model to `modelContextWindows` to persist them:
 

--- a/src/chat/__tests__/contextWindow.test.ts
+++ b/src/chat/__tests__/contextWindow.test.ts
@@ -1,6 +1,7 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  hasSeparateOutputWindow,
   parseContextOverflowError,
   resolveContextWindowOverride,
   serverReportedContext,
@@ -22,6 +23,7 @@ describe('serverReportedContext', () => {
   test('prefers max_model_len over every other field', () => {
     const model = baseModel({
       max_model_len: 131072,
+      max_input_tokens: 200000,
       context_length: 8192,
       context_window: 4096,
       meta: { n_ctx: 2048, n_ctx_train: 1024 },
@@ -68,6 +70,36 @@ describe('serverReportedMaxOutput', () => {
     assert.equal(serverReportedMaxOutput(baseModel()), undefined);
     assert.equal(serverReportedMaxOutput(baseModel({ max_output_tokens: 0 })), undefined);
     assert.equal(serverReportedMaxOutput(baseModel({ max_output_tokens: -1 })), undefined);
+  });
+});
+
+describe('hasSeparateOutputWindow', () => {
+  test('true for LiteLLM input/output ceilings that differ', () => {
+    const model = baseModel({ max_input_tokens: 200000, max_output_tokens: 64000 });
+    assert.equal(hasSeparateOutputWindow(model), true);
+  });
+
+  test('false when max_model_len is present — a shared vLLM-style window', () => {
+    const model = baseModel({
+      max_model_len: 32768,
+      max_input_tokens: 32768,
+      max_output_tokens: 4096,
+    });
+    assert.equal(hasSeparateOutputWindow(model), false);
+  });
+
+  test('false when the ceilings match — one pool described twice', () => {
+    const model = baseModel({ max_input_tokens: 8192, max_output_tokens: 8192 });
+    assert.equal(hasSeparateOutputWindow(model), false);
+  });
+
+  test('false when either ceiling is missing or unusable', () => {
+    assert.equal(hasSeparateOutputWindow(baseModel({ max_input_tokens: 200000 })), false);
+    assert.equal(hasSeparateOutputWindow(baseModel({ max_output_tokens: 64000 })), false);
+    assert.equal(
+      hasSeparateOutputWindow(baseModel({ max_input_tokens: 200000, max_output_tokens: 0 })),
+      false
+    );
   });
 });
 

--- a/src/chat/__tests__/tokenBudget.test.ts
+++ b/src/chat/__tests__/tokenBudget.test.ts
@@ -178,6 +178,67 @@ describe('calculateSafeMaxOutputTokens', () => {
   });
 });
 
+describe('separate output windows (LiteLLM)', () => {
+  test('calculateMaxInputTokens reserves nothing when the output window is separate', () => {
+    const params = {
+      modelMaxContext: 200000,
+      configuredMaxOutput: 64000,
+      toolsSerializedLength: 0,
+    };
+    const shared = calculateMaxInputTokens(params);
+    const separate = calculateMaxInputTokens({ ...params, outputWindowIsSeparate: true });
+
+    // The whole point of the fix: the 64K completion allowance must not be
+    // carved out of a prompt-only ceiling.
+    assert.ok(
+      separate > shared,
+      `expected a separate window to free up prompt space (${separate} vs ${shared})`
+    );
+    assert.equal(
+      separate,
+      Math.floor(
+        (params.modelMaxContext - TOKEN_CONSTANTS.CONTEXT_BUFFER_TOKENS) /
+          TOKEN_CONSTANTS.INPUT_OVERHEAD_RATIO
+      )
+    );
+  });
+
+  test('calculateSafeMaxOutputTokens ignores prompt size when the window is separate', () => {
+    const result = calculateSafeMaxOutputTokens({
+      estimatedInputTokens: 150000,
+      toolsOverhead: 5000,
+      modelMaxContext: 200000,
+      configuredMaxOutput: 64000,
+      outputWindowIsSeparate: true,
+    });
+    assert.equal(result, 64000);
+  });
+
+  test('still floors a separate window at MIN_OUTPUT_TOKENS', () => {
+    const result = calculateSafeMaxOutputTokens({
+      estimatedInputTokens: 10,
+      toolsOverhead: 0,
+      modelMaxContext: 200000,
+      configuredMaxOutput: 1,
+      outputWindowIsSeparate: true,
+    });
+    assert.equal(result, TOKEN_CONSTANTS.MIN_OUTPUT_TOKENS);
+  });
+
+  test('shared-window behaviour is unchanged when the flag is absent', () => {
+    const shared = {
+      estimatedInputTokens: 150000,
+      toolsOverhead: 5000,
+      modelMaxContext: 200000,
+      configuredMaxOutput: 64000,
+    };
+    assert.equal(
+      calculateSafeMaxOutputTokens(shared),
+      calculateSafeMaxOutputTokens({ ...shared, outputWindowIsSeparate: false })
+    );
+  });
+});
+
 describe('calculateMaxInputTokens', () => {
   test('reserves half the context for output when half is less than configured max', () => {
     const result = calculateMaxInputTokens({

--- a/src/chat/contextWindow.ts
+++ b/src/chat/contextWindow.ts
@@ -45,6 +45,28 @@ export function serverReportedMaxOutput(model: OpenAIModel): number | undefined 
 }
 
 /**
+ * True when the server described two *independent* ceilings rather than one
+ * shared window. LiteLLM's `max_input_tokens` is a prompt-only limit and
+ * `max_output_tokens` a separate completion limit — an Anthropic model proxied
+ * through LiteLLM accepts 200K in *and* 64K out, not 200K combined. Budgeting
+ * such a model as a shared window silently costs the user a third of their
+ * usable prompt (follow-up to PR #78, which introduced the two fields).
+ *
+ * Deliberately narrow, because being wrong in the other direction produces
+ * real context-overflow errors rather than merely wasted headroom:
+ *  - `max_model_len` means a vLLM-style shared window is on offer (LiteLLM
+ *    passes it straight through), so output must still come out of it;
+ *  - equal ceilings mean the server described one pool twice, not two windows.
+ */
+export function hasSeparateOutputWindow(model: OpenAIModel): boolean {
+  if (isUsableContext(model.max_model_len)) {
+    return false;
+  }
+  const { max_input_tokens: input, max_output_tokens: output } = model;
+  return isUsableContext(input) && isUsableContext(output) && output < input;
+}
+
+/**
  * Resolve the user-configured context override for `modelId` from the
  * `modelContextWindows` setting. Keys match the model id exactly or via `*`
  * wildcards (case-insensitive), mirroring `perModelOptions`; an exact-id

--- a/src/chat/tokenBudget.ts
+++ b/src/chat/tokenBudget.ts
@@ -125,6 +125,12 @@ export interface SafeOutputTokensParams {
   toolsOverhead: number;
   modelMaxContext: number;
   configuredMaxOutput: number;
+  /**
+   * Set when `modelMaxContext` is an input-only ceiling and the model has its
+   * own separate completion window (LiteLLM). Output then doesn't compete with
+   * the prompt for space. See {@link hasSeparateOutputWindow}.
+   */
+  outputWindowIsSeparate?: boolean;
 }
 
 /**
@@ -133,6 +139,12 @@ export interface SafeOutputTokensParams {
  * slack to account for tokenizer drift and a fixed CONTEXT_BUFFER_TOKENS.
  */
 export function calculateSafeMaxOutputTokens(params: SafeOutputTokensParams): number {
+  // Two independent windows: the prompt can't crowd out the completion, so the
+  // model's own output ceiling is the only bound that applies.
+  if (params.outputWindowIsSeparate) {
+    return Math.max(TOKEN_CONSTANTS.MIN_OUTPUT_TOKENS, params.configuredMaxOutput);
+  }
+
   const totalEstimatedTokens = params.estimatedInputTokens + params.toolsOverhead;
   const conservativeInputEstimate = Math.ceil(
     totalEstimatedTokens * TOKEN_CONSTANTS.INPUT_OVERHEAD_RATIO
@@ -150,6 +162,8 @@ export interface MaxInputTokensParams {
   modelMaxContext: number;
   configuredMaxOutput: number;
   toolsSerializedLength: number;
+  /** See {@link SafeOutputTokensParams.outputWindowIsSeparate}. */
+  outputWindowIsSeparate?: boolean;
 }
 
 /**
@@ -164,10 +178,12 @@ export interface MaxInputTokensParams {
  * MIN_OUTPUT_TOKENS (issue #74).
  */
 export function calculateMaxInputTokens(params: MaxInputTokensParams): number {
-  const desiredOutputTokens = Math.min(
-    params.configuredMaxOutput,
-    Math.floor(params.modelMaxContext / 2)
-  );
+  // With a separate completion window there is nothing to reserve — carving
+  // output out of an input-only ceiling throws away prompt space the server
+  // was always willing to accept.
+  const desiredOutputTokens = params.outputWindowIsSeparate
+    ? 0
+    : Math.min(params.configuredMaxOutput, Math.floor(params.modelMaxContext / 2));
   const toolsRawEstimate = Math.ceil(
     params.toolsSerializedLength / TOKEN_CONSTANTS.CHARS_PER_TOKEN
   );

--- a/src/models/__tests__/modelInfoBuilder.test.ts
+++ b/src/models/__tests__/modelInfoBuilder.test.ts
@@ -208,6 +208,51 @@ describe('buildModelInfo output token math', () => {
     assert.equal(info.maxOutputTokens, totalContext - TOKEN_CONSTANTS.ADJUST_TOKEN_BUFFER);
   });
 
+  test('keeps a separate LiteLLM output window intact instead of clamping it', () => {
+    const { info, outputWindowIsSeparate } = buildModelInfo({
+      model: baseModel({ max_input_tokens: 200000, max_output_tokens: 64000 }),
+      defaultMaxTokens: 32768,
+      defaultMaxOutputTokens: 2048,
+      capabilities: {},
+    });
+    assert.equal(outputWindowIsSeparate, true);
+    assert.equal(info.maxInputTokens, 200000);
+    assert.equal(info.maxOutputTokens, 64000);
+  });
+
+  test('a modelContextWindows override forces shared-window budgeting', () => {
+    const { info, outputWindowIsSeparate } = buildModelInfo({
+      model: baseModel({ max_input_tokens: 200000, max_output_tokens: 64000 }),
+      defaultMaxTokens: 32768,
+      defaultMaxOutputTokens: 2048,
+      capabilities: {},
+      contextOverride: 8192,
+    });
+    assert.equal(outputWindowIsSeparate, false);
+    assert.equal(info.maxOutputTokens, 8192 - TOKEN_CONSTANTS.ADJUST_TOKEN_BUFFER);
+  });
+
+  test('a backend-discovered context forces shared-window budgeting', () => {
+    const { outputWindowIsSeparate } = buildModelInfo({
+      model: baseModel({ max_input_tokens: 200000, max_output_tokens: 64000 }),
+      defaultMaxTokens: 32768,
+      defaultMaxOutputTokens: 2048,
+      capabilities: {},
+      discoveredContext: 8192,
+    });
+    assert.equal(outputWindowIsSeparate, false);
+  });
+
+  test('a shared vLLM window is never treated as separate', () => {
+    const { outputWindowIsSeparate } = buildModelInfo({
+      model: baseModel({ max_model_len: 32768 }),
+      defaultMaxTokens: 32768,
+      defaultMaxOutputTokens: 2048,
+      capabilities: {},
+    });
+    assert.equal(outputWindowIsSeparate, false);
+  });
+
   test('reduces maxOutputTokens to leave the ADJUST_TOKEN_BUFFER headroom when the window is tight', () => {
     const totalContext = 512;
     const { info } = buildModelInfo({

--- a/src/models/modelInfoBuilder.ts
+++ b/src/models/modelInfoBuilder.ts
@@ -7,7 +7,11 @@
 
 import { OpenAIModel } from '../api/types';
 import { describeModel, friendlyModelName, inferModelFamily } from './modelDisplay';
-import { serverReportedContext, serverReportedMaxOutput } from '../chat/contextWindow';
+import {
+  hasSeparateOutputWindow,
+  serverReportedContext,
+  serverReportedMaxOutput,
+} from '../chat/contextWindow';
 import { TOKEN_CONSTANTS } from '../chat/tokenBudget';
 
 /**
@@ -68,6 +72,13 @@ export interface BuildModelInfoResult {
   };
   readonly totalContext: number;
   readonly hasServerReportedContext: boolean;
+  /**
+   * True when `totalContext` is an input-only ceiling and the model has its own
+   * separate completion window, so the chat path must not reserve output space
+   * out of it. Always false once a user override or a backend-discovered size
+   * is in play — those describe one shared window.
+   */
+  readonly outputWindowIsSeparate: boolean;
 }
 
 /**
@@ -92,13 +103,27 @@ export function buildModelInfo({
   const serverMaxOutput = serverReportedMaxOutput(model);
   const totalContext =
     contextOverride ?? discoveredContext ?? serverContext ?? defaultMaxTokens;
-  const maxOutputTokens = Math.min(
-    serverMaxOutput ?? defaultMaxOutputTokens,
-    Math.max(
-      TOKEN_CONSTANTS.MIN_OUTPUT_TOKENS,
-      totalContext - TOKEN_CONSTANTS.ADJUST_TOKEN_BUFFER
-    )
-  );
+
+  // Only believe the server's two-window story when the server's own context
+  // value is the one we ended up using. A `modelContextWindows` override or an
+  // Ollama-discovered size describes a single shared window, so output still
+  // has to be carved out of it.
+  const outputWindowIsSeparate =
+    contextOverride === undefined &&
+    discoveredContext === undefined &&
+    serverContext !== undefined &&
+    hasSeparateOutputWindow(model);
+
+  const outputCeiling = serverMaxOutput ?? defaultMaxOutputTokens;
+  const maxOutputTokens = outputWindowIsSeparate
+    ? outputCeiling
+    : Math.min(
+        outputCeiling,
+        Math.max(
+          TOKEN_CONSTANTS.MIN_OUTPUT_TOKENS,
+          totalContext - TOKEN_CONSTANTS.ADJUST_TOKEN_BUFFER
+        )
+      );
 
   const description = describeModel(model);
   const tooltip = description ? `${model.id} — ${description}` : model.id;
@@ -123,5 +148,6 @@ export function buildModelInfo({
     info,
     totalContext,
     hasServerReportedContext: serverContext !== undefined,
+    outputWindowIsSeparate,
   };
 }

--- a/src/provider/__tests__/modelCatalog.test.ts
+++ b/src/provider/__tests__/modelCatalog.test.ts
@@ -277,6 +277,60 @@ describe('ModelCatalog.resolveModelMaxContext', () => {
   });
 });
 
+describe('ModelCatalog.hasSeparateOutputWindow', () => {
+  /** A LiteLLM-shaped entry: prompt-only ceiling plus a smaller output one. */
+  function liteLLMResponse(): OpenAIModelsResponse {
+    return {
+      object: 'list',
+      data: [
+        {
+          id: 'a',
+          object: 'model',
+          created: 0,
+          owned_by: 'litellm',
+          max_input_tokens: 200000,
+          max_output_tokens: 64000,
+        },
+      ],
+    };
+  }
+
+  test('reports true once a LiteLLM model has been fetched', async () => {
+    const h = makeCatalog({ fetchModels: () => Promise.resolve(liteLLMResponse()) });
+    await h.catalog.getOrFetchModels(fakeToken());
+    assert.equal(h.catalog.hasSeparateOutputWindow(chatInfo('a', 200000)), true);
+  });
+
+  test('defaults to false before any fetch', () => {
+    const h = makeCatalog({ fetchModels: () => Promise.resolve(liteLLMResponse()) });
+    assert.equal(h.catalog.hasSeparateOutputWindow(chatInfo('a', 200000)), false);
+  });
+
+  test('false for a shared vLLM window', async () => {
+    const h = makeCatalog({
+      fetchModels: () => Promise.resolve(modelsResponse({ id: 'a', contextLen: 32768 })),
+    });
+    await h.catalog.getOrFetchModels(fakeToken());
+    assert.equal(h.catalog.hasSeparateOutputWindow(chatInfo('a', 32768)), false);
+  });
+
+  test('an overflow error proves one combined limit and flips it back to shared', async () => {
+    const h = makeCatalog({ fetchModels: () => Promise.resolve(liteLLMResponse()) });
+    await h.catalog.getOrFetchModels(fakeToken());
+    const model = chatInfo('a', 200000);
+    assert.equal(h.catalog.hasSeparateOutputWindow(model), true);
+
+    h.catalog.learnContextSizeFromError(
+      model,
+      new Error('maximum context length is 8192 tokens')
+    );
+    assert.equal(h.catalog.hasSeparateOutputWindow(model), false);
+
+    h.catalog.clearLearnedContexts();
+    assert.equal(h.catalog.hasSeparateOutputWindow(model), true);
+  });
+});
+
 describe('ModelCatalog.learnContextSizeFromError', () => {
   test('learns a smaller context from an overflow error and applies it', () => {
     const h = makeCatalog({ fetchModels: () => Promise.resolve(modelsResponse()) });

--- a/src/provider/chatRequestHandler.ts
+++ b/src/provider/chatRequestHandler.ts
@@ -181,10 +181,14 @@ export class ChatRequestHandler {
     // model's current context size, so a corrected context can re-run it.
     const attempt = async (): Promise<void> => {
       const modelMaxContext = catalog.resolveModelMaxContext(model);
+      // Re-read per attempt: a context learned from an overflow error proves
+      // the server enforces one combined limit, which flips this back to false.
+      const outputWindowIsSeparate = catalog.hasSeparateOutputWindow(model);
       const maxInputTokens = calculateMaxInputTokens({
         modelMaxContext,
         configuredMaxOutput,
         toolsSerializedLength,
+        outputWindowIsSeparate,
       });
 
       const truncatedMessages = truncateMessagesToFit(openAIMessages, maxInputTokens, log);
@@ -202,10 +206,13 @@ export class ChatRequestHandler {
         toolsOverhead,
         modelMaxContext,
         configuredMaxOutput,
+        outputWindowIsSeparate,
       });
 
       log(
-        `Token estimate: input=${estimatedInputTokens}, tools=${toolsOverhead}, model_context=${modelMaxContext}, chosen_max_tokens=${safeMaxOutputTokens}`
+        `Token estimate: input=${estimatedInputTokens}, tools=${toolsOverhead}, model_context=${modelMaxContext}${
+          outputWindowIsSeparate ? ' (input-only)' : ''
+        }, chosen_max_tokens=${safeMaxOutputTokens}`
       );
       if (safeMaxOutputTokens <= TOKEN_CONSTANTS.MIN_OUTPUT_TOKENS) {
         log(

--- a/src/provider/modelCatalog.ts
+++ b/src/provider/modelCatalog.ts
@@ -55,6 +55,13 @@ export class ModelCatalog {
    */
   private readonly learnedContextByModelId: Map<string, number> = new Map();
   /**
+   * Model ids whose context is an input-only ceiling with a separate
+   * completion window (LiteLLM). The chat path must not reserve output space
+   * out of their context. Rebuilt on every model fetch alongside
+   * `contextByModelId`.
+   */
+  private readonly separateOutputWindowModelIds: Set<string> = new Set();
+  /**
    * Backend-discovered metadata per model id (context, sampler params,
    * capabilities — e.g. from Ollama `/api/show`). Rebuilt on every model
    * fetch; empty for backends without native discovery. Lets the chat path
@@ -183,6 +190,7 @@ export class ModelCatalog {
     // concurrent chat request sees no context/params at all.
     const nextContextByModelId = new Map<string, number>();
     const nextDiscoveredByModelId = new Map<string, DiscoveredModelInfo>();
+    const nextSeparateOutputWindowModelIds = new Set<string>();
 
     const config = this.deps.getConfig();
     const models = await Promise.all(
@@ -204,7 +212,7 @@ export class ModelCatalog {
           nextDiscoveredByModelId.set(model.id, discovered);
         }
 
-        const { info, totalContext, hasServerReportedContext } = buildModelInfo({
+        const { info, totalContext, hasServerReportedContext, outputWindowIsSeparate } = buildModelInfo({
           model,
           defaultMaxTokens: config.defaultMaxTokens,
           defaultMaxOutputTokens: config.defaultMaxOutputTokens,
@@ -218,8 +226,13 @@ export class ModelCatalog {
           discoveredContext: discovered?.contextLength,
         });
         nextContextByModelId.set(model.id, totalContext);
+        if (outputWindowIsSeparate) {
+          nextSeparateOutputWindowModelIds.add(model.id);
+        }
 
-        const exposed = `exposed as input=${info.maxInputTokens}, output=${info.maxOutputTokens}`;
+        const exposed = `exposed as input=${info.maxInputTokens}, output=${info.maxOutputTokens}${
+          outputWindowIsSeparate ? ', separate output window' : ''
+        }`;
         if (contextOverride !== undefined) {
           log(
             `  Model ${model.id}: context ${totalContext} tokens from 'modelContextWindows' setting (${exposed})`
@@ -254,11 +267,15 @@ export class ModelCatalog {
     // gone so stale data can't leak into future chat requests.
     this.contextByModelId.clear();
     this.discoveredByModelId.clear();
+    this.separateOutputWindowModelIds.clear();
     for (const [id, context] of nextContextByModelId) {
       this.contextByModelId.set(id, context);
     }
     for (const [id, discovered] of nextDiscoveredByModelId) {
       this.discoveredByModelId.set(id, discovered);
+    }
+    for (const id of nextSeparateOutputWindowModelIds) {
+      this.separateOutputWindowModelIds.add(id);
     }
 
     log(`Found ${models.length} models: ${models.map((m) => m.id).join(', ')}`);
@@ -292,6 +309,23 @@ export class ModelCatalog {
       return learned;
     }
     return context;
+  }
+
+  /**
+   * Whether {@link resolveModelMaxContext} returned an input-only ceiling that
+   * the model's completion window doesn't share. Callers use it to skip
+   * reserving output space out of the prompt budget.
+   *
+   * Defaults to false whenever we can't be sure — before the first model fetch,
+   * or once the server has told us (via an overflow error) that it enforces a
+   * single combined limit after all. Guessing false only costs headroom;
+   * guessing true costs failed requests.
+   */
+  public hasSeparateOutputWindow(model: LanguageModelChatInformation): boolean {
+    if (!this.separateOutputWindowModelIds.has(model.id)) {
+      return false;
+    }
+    return !this.learnedContextByModelId.has(model.id);
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #78, which surfaced LiteLLM's `max_input_tokens` / `max_output_tokens` but budgeted the output allowance out of the prompt window — silently costing ~31% of usable input context for exactly the models it targeted. This PR teaches the gateway the difference between a **shared** context window (vLLM, llama.cpp, Ollama) and LiteLLM's **separate** input/output ceilings, and only reserves output space when the window is genuinely shared.

## Problem

LiteLLM's `max_input_tokens` is a prompt-only ceiling and `max_output_tokens` an independent completion allowance — a model advertised as 200K in / 64K out accepts both, not 200K combined (confirmed against LiteLLM's `model_prices_and_context_window.json`). The budget math, however, assumes one shared pool and carves the output reservation out of the input window:

| Claude via LiteLLM (200K in / 64K out) | usable input budget |
|---|---|
| Before #78 | 163,040 |
| After #78 | **113,120** ⚠️ |
| This PR | **166,453** ✅ |

The regression failed safe (never an overflow error, just wasted headroom), but conversations truncated ~50K tokens earlier than the server allows.

## Fix

- **`hasSeparateOutputWindow()`** (`contextWindow.ts`) recognises the two-window shape. Deliberately narrow — `max_model_len` must be absent and the output ceiling strictly smaller than the input one — because guessing "shared" only costs headroom, while guessing "separate" causes failed requests. A LiteLLM proxy fronting vLLM (which passes `max_model_len` through) and a server describing one pool twice (equal ceilings) both stay on the shared path.
- **`calculateMaxInputTokens` / `calculateSafeMaxOutputTokens`** accept an `outputWindowIsSeparate` flag: reserve nothing for output, and let the model's own ceiling bound the completion regardless of prompt size.
- **`buildModelInfo`** only engages the flag when the server's own context value is the one in use — a `modelContextWindows` override or an Ollama-discovered size describes a single shared window and keeps the existing clamped behaviour.
- **`ModelCatalog.hasSeparateOutputWindow()`** answers false whenever it can't be sure: before the first model fetch, and after a context-overflow error proves the server enforces one combined limit after all. The error flips the model back to shared budgeting for the session (cleared on config reload, matching learned context sizes), and the flag is re-read per attempt so the transparent retry uses the corrected budget.

Worst case against a server that advertises separate windows but enforces a combined limit: one failed request, transparently retried — the same guarantee already given to llama-server router mode.

Also fixes two smaller review findings from #78: README drift (`max_model_len` is passed through by LiteLLM when fronting vLLM, matching the code comments) and an untested precedence — the existing `prefers max_model_len over every other field` fixture now includes `max_input_tokens`.

## Behaviour matrix

| Scenario | Budgeting | Change |
|---|---|---|
| LiteLLM, `max_input_tokens` > `max_output_tokens` | separate | input 113,120 → **166,453** |
| vLLM `max_model_len` | shared | byte-identical |
| LiteLLM fronting vLLM (`max_model_len` present) | shared | byte-identical |
| Equal ceilings (one pool described twice) | shared | byte-identical |
| `modelContextWindows` override / Ollama-discovered context | shared | byte-identical |
| After a context-overflow error | shared (learned) | flips back for the session |

## Testing

- 434/434 tests pass (16 new: detection edge cases, budget math for both window kinds, builder precedence, and the catalog's overflow flip-back)
- End-to-end simulation of the lying-server scenario: trusts separate → overflow → learns 131,072 → retry fits (input 55,680 / output 10,816) → config reload restores
- Each commit is independently green (426 → 430 → 434)
- `tsc --noEmit` clean, ESLint 0 errors, esbuild bundles at 143.0kb
