### PR TITLE
Fix/issue 86

### DIFF
--- a/src/chat/__tests__/responseStreamer.test.ts
+++ b/src/chat/__tests__/responseStreamer.test.ts
@@ -93,6 +93,7 @@ describe('streamResponse', () => {
     assert.equal(stats.hadThinking, true);
     const kinds = events.map((e) => e.kind);
     assert.deepEqual(kinds, ['thinking', 'thinkingDone']);
+    assert.equal(isEmptyStreamResult(stats), true);
   });
 
   test('parses inline <thinking> tags in content', async () => {
@@ -331,7 +332,7 @@ describe('isEmptyStreamResult', () => {
     );
   });
 
-  test('false when thinking occurred', () => {
+  test('true when thinking occurred without visible output', () => {
     assert.equal(
       isEmptyStreamResult({
         totalContentLength: 0,
@@ -340,7 +341,7 @@ describe('isEmptyStreamResult', () => {
         hadThinking: true,
         thinkingForceClosed: false,
       }),
-      false
+      true
     );
   });
 

--- a/src/chat/__tests__/tokenBudget.test.ts
+++ b/src/chat/__tests__/tokenBudget.test.ts
@@ -109,6 +109,81 @@ describe('truncateMessagesToFit', () => {
     );
   });
 
+  test('does not retain a tool result without its assistant tool call', () => {
+    const messages = [
+      { role: 'system', content: 's' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          { id: 'call-1', type: 'function', function: { name: 'search', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call-1', content: 'r' },
+    ];
+
+    const result = truncateMessagesToFit(messages, 2);
+
+    assert.deepEqual(result, [messages[0]]);
+  });
+
+  test('retains a complete parallel tool exchange when the whole group fits', () => {
+    const messages = [
+      { role: 'system', content: 's' },
+      { role: 'user', content: 'x'.repeat(400) },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          { id: 'call-1', type: 'function', function: { name: 'first', arguments: '{}' } },
+          { id: 'call-2', type: 'function', function: { name: 'second', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call-1', content: 'a' },
+      { role: 'tool', tool_call_id: 'call-2', content: 'b' },
+    ];
+    const groupBudget = [messages[0], ...messages.slice(2)]
+      .reduce((total, message) => total + estimateMessageTokens(message), 0);
+
+    const result = truncateMessagesToFit(messages, groupBudget);
+
+    assert.deepEqual(result, [messages[0], ...messages.slice(2)]);
+  });
+
+  test('drops every result when a parallel tool exchange does not fully fit', () => {
+    const messages = [
+      { role: 'system', content: 's' },
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          { id: 'call-1', type: 'function', function: { name: 'first', arguments: '{}' } },
+          { id: 'call-2', type: 'function', function: { name: 'second', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call-1', content: 'a' },
+      { role: 'tool', tool_call_id: 'call-2', content: 'b' },
+    ];
+
+    const result = truncateMessagesToFit(messages, 3);
+
+    assert.deepEqual(result, [messages[0]]);
+  });
+
+  test('filters an unmatched tool result from malformed truncated history', () => {
+    const messages = [
+      { role: 'system', content: 's' },
+      { role: 'user', content: 'x'.repeat(100) },
+      { role: 'tool', tool_call_id: 'missing', content: 'r' },
+    ];
+    const logs: string[] = [];
+
+    const result = truncateMessagesToFit(messages, 2, (message) => logs.push(message));
+
+    assert.deepEqual(result, [messages[0]]);
+    assert.ok(logs.some((message) => message.includes('Dropped 1 orphaned tool result')));
+  });
+
   test('logs truncation events when provided a logger', () => {
     const messages = [
       { content: 'a'.repeat(40) },

--- a/src/chat/responseStreamer.ts
+++ b/src/chat/responseStreamer.ts
@@ -197,15 +197,14 @@ export async function streamResponse(params: StreamResponseParams): Promise<Stre
 
 /**
  * Determine whether a completed stream should be treated as empty (and thus
- * needs an error fallback message). A stream with thinking content but no
- * visible output is still "empty" from the user's perspective only if the
- * thinking block was force-closed.
+ * needs an error fallback message). Thinking content is not a visible response
+ * for VS Code's purposes. Force-closed thinking is excluded because
+ * streamResponse already emits its dedicated fallback text.
  */
 export function isEmptyStreamResult(stats: StreamStats): boolean {
   return (
-    stats.totalContentLength === 0 &&
+    stats.totalTextParts === 0 &&
     stats.totalToolCalls === 0 &&
-    !stats.hadThinking &&
     !stats.thinkingForceClosed
   );
 }

--- a/src/chat/tokenBudget.ts
+++ b/src/chat/tokenBudget.ts
@@ -29,7 +29,30 @@ const NOOP_LOGGER: TokenLogger = () => {
  */
 export interface TokenEstimableMessage {
   content?: string | object | null;
+  role?: string;
+  tool_call_id?: string;
   tool_calls?: unknown;
+}
+
+function getToolCallIds(message: TokenEstimableMessage): Set<string> {
+  const ids = new Set<string>();
+  if (message.role !== 'assistant' || !Array.isArray(message.tool_calls)) {
+    return ids;
+  }
+  for (const toolCall of message.tool_calls) {
+    if (typeof toolCall === 'object' && toolCall !== null) {
+      const id = (toolCall as { id?: unknown }).id;
+      if (typeof id === 'string') {
+        ids.add(id);
+      }
+    }
+  }
+  return ids;
+}
+
+function isToolResultFor(message: TokenEstimableMessage, toolCallIds: Set<string>): boolean {
+  const toolCallId = message.tool_call_id;
+  return message.role === 'tool' && typeof toolCallId === 'string' && toolCallIds.has(toolCallId);
 }
 
 /**
@@ -75,8 +98,10 @@ export function buildInputText(messages: readonly TokenEstimableMessage[]): stri
  * Truncate messages to fit within `maxTokens`.
  *
  * Strategy: always keep the first message (typically the system prompt) and
- * as many trailing messages as will fit, working backwards from the end.
- * Mid-conversation messages are dropped first.
+ * as many trailing message groups as will fit, working backwards from the end.
+ * An assistant tool call and its adjacent results form one group so truncation
+ * cannot retain only half of a tool exchange. Mid-conversation groups are
+ * dropped first.
  */
 export function truncateMessagesToFit<T extends TokenEstimableMessage>(
   messages: readonly T[],
@@ -101,23 +126,60 @@ export function truncateMessagesToFit<T extends TokenEstimableMessage>(
 
   log(`Context overflow: ${totalTokens} tokens > ${maxTokens} limit. Truncating...`);
 
-  const result: T[] = [messages[0]];
-  let usedTokens = messageTokens[0];
+  const units: Array<{ messages: T[]; tokens: number }> = [];
+  for (let i = 1; i < messages.length;) {
+    const unitMessages = [messages[i]];
+    let unitTokens = messageTokens[i];
+    const toolCallIds = getToolCallIds(messages[i]);
+    i++;
 
-  const recentMessages: T[] = [];
-  for (let i = messages.length - 1; i > 0; i--) {
-    const msgTokens = messageTokens[i];
-    if (usedTokens + msgTokens <= maxTokens) {
-      recentMessages.unshift(messages[i]);
-      usedTokens += msgTokens;
+    while (
+      i < messages.length &&
+      isToolResultFor(messages[i], toolCallIds)
+    ) {
+      unitMessages.push(messages[i]);
+      unitTokens += messageTokens[i];
+      i++;
+    }
+    units.push({ messages: unitMessages, tokens: unitTokens });
+  }
+
+  let usedTokens = messageTokens[0];
+  const recentUnits: T[][] = [];
+  for (let i = units.length - 1; i >= 0; i--) {
+    if (usedTokens + units[i].tokens <= maxTokens) {
+      recentUnits.unshift(units[i].messages);
+      usedTokens += units[i].tokens;
     } else {
       break;
     }
   }
 
-  result.push(...recentMessages);
-  log(`Truncated: kept ${result.length}/${messages.length} messages, ~${usedTokens} tokens`);
-  return result;
+  const result = [messages[0], ...recentUnits.flat()];
+  const retainedToolCallIds = new Set<string>();
+  for (const message of result) {
+    for (const id of getToolCallIds(message)) {
+      retainedToolCallIds.add(id);
+    }
+  }
+
+  let droppedOrphans = 0;
+  const validatedResult = result.filter((message) => {
+    const isOrphan =
+      message.role === 'tool' &&
+      typeof message.tool_call_id === 'string' &&
+      !retainedToolCallIds.has(message.tool_call_id);
+    if (isOrphan) {
+      droppedOrphans++;
+      usedTokens -= estimateMessageTokens(message);
+    }
+    return !isOrphan;
+  });
+  if (droppedOrphans > 0) {
+    log(`Dropped ${droppedOrphans} orphaned tool result message(s) after truncation`);
+  }
+  log(`Truncated: kept ${validatedResult.length}/${messages.length} messages, ~${usedTokens} tokens`);
+  return validatedResult;
 }
 
 export interface SafeOutputTokensParams {


### PR DESCRIPTION
Updated todo list

## Summary

Fix chat context truncation and empty-response handling for tool calls and thinking-only model responses.

## Changes

- Keep assistant tool calls together with their adjacent tool results during context truncation.
- Prevent truncated histories from retaining orphaned tool-result messages.
- Log when orphaned tool results are removed.
- Treat thinking-only responses as empty when no visible text or tool calls were produced.
- Preserve the dedicated fallback behavior for force-closed thinking streams.
- Add regression tests for parallel tool calls, incomplete exchanges, orphaned results, and thinking-only responses.

## Testing

- TypeScript test build passed.
- All 438 tests passed:
  - `npx tsc -p tsconfig.test.json`
  - `node --test "out-test/**/*.test.js"`

Note: the package’s `npm test` script currently uses Unix `rm`, which is not available in PowerShell on Windows.