### PR TITLE
feat: append per-reply token usage summary line

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,21 @@ Access from the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 | **GitHub Copilot LLM Gateway: Edit Custom Headers**    | Add, edit, or remove custom HTTP headers (stored in secret storage) |
 | **GitHub Copilot LLM Gateway: Show Output Log**        | Open the extension's output channel                                 |
 
+## Reply Token Summary
+
+GitHub Copilot's native chat footer shows a **credits** figure, which is meaningless for a self-hosted gateway model (gateway models report `multiplierNumeric: 0` — they never consume Copilot premium quota). Instead, when this setting is on, the extension appends a plain-text summary line to the end of each reply:
+
+```
+Tokens: input 12,345 | output 1,234 | total 13,579
+```
+
+- **Scope is one completed reply**, including all of its internal tool-call rounds — not the whole chat conversation, and not the extension's lifetime session totals shown in the [status dialog](#status-bar--connection-info). Nested subagent calls (a tool that spawns its own separate chat) are **not** rolled into the parent reply's total.
+- Counts are **server-reported usage**, summed once per actual model call — not a token estimate. Because each round of a multi-step tool-calling reply resends the growing conversation, the input count is the sum of what was *actually sent* on each call, not a single context-window snapshot.
+- If the server didn't report usage for one round, the line reads `Tokens (partial): …` using only the rounds that did. If no round ever reported usage, it reads `Tokens: input unavailable | output unavailable | total unavailable`.
+- The line is ordinary assistant text, so it is included if you copy or export the reply, and (like any other assistant text) becomes part of the conversation history sent on later turns — it is not counted as part of this reply's own output tokens.
+- Setting: `github.copilot.llm-gateway.showReplyTokenUsage` (default: on). Turn it off to get the previous plain-reply behavior with no added line.
+- **Compatibility note**: linking a reply's tool-call rounds together requires per-request identity fields that Copilot Chat passes internally but does not publish as a stable API. If your installed Copilot Chat build doesn't supply them, this feature silently does nothing — no line is added, and nothing else about the reply changes. This does not affect the [context-window usage widget](#what-it-does-that-a-plain-connection-doesnt), which uses a separate, stable mechanism.
+
 ## Privacy & Network Requests
 
 This extension is a **Language Model provider** — it registers alongside GitHub's built-in models and handles inference when you select an LLM Gateway model. Understanding what it does and does not control is important:

--- a/package.json
+++ b/package.json
@@ -240,6 +240,12 @@
           "minimum": 1,
           "description": "Maximum characters of context after the cursor to send for inline completions. Lower values reduce latency but provide less context.",
           "order": 20
+        },
+        "github.copilot.llm-gateway.showReplyTokenUsage": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Append a `Tokens: input \u2026 | output \u2026 | total \u2026` line to the end of each reply, summing this gateway's server-reported usage across that reply's internal tool-call rounds (a completed reply, not the whole chat). This is separate from GitHub Copilot's own credits/quota display, which this extension cannot change. Requires the installed Copilot Chat build to supply private, unstable per-request identity fields; if it doesn't, no line is added and nothing else changes. Disable to restore the previous plain-text behavior.",
+          "order": 22
         }
       }
     }

--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -208,6 +208,7 @@ describe('streamChatCompletion reasoning field handling (issue #59)', () => {
     inlineCompletionTimeout: 5000,
     inlineCompletionMaxPrefixChars: 4000,
     inlineCompletionMaxSuffixChars: 2000,
+    showReplyTokenUsage: true,
   };
 
   const token = {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -5,6 +5,7 @@ import {
   OpenAICompletionResponse,
   OpenAIModelsResponse,
   OpenAIUsage,
+  OpenAIUsageAvailability,
 } from './types';
 import { GatewayConfig } from '../config/gatewayConfig';
 import {
@@ -77,6 +78,8 @@ export interface GatewayStreamChunk {
   tool_calls: AccumulatedToolCall[];
   finished_tool_calls: AccumulatedToolCall[];
   usage?: OpenAIUsage;
+  /** Field-presence companion to `usage` — see {@link OpenAIUsageAvailability}. */
+  usageAvailability?: OpenAIUsageAvailability;
 }
 
 /**
@@ -448,6 +451,7 @@ export class GatewayClient {
         tool_calls: [],
         finished_tool_calls: [],
         usage,
+        usageAvailability: extractUsageAvailability(obj.usage),
       };
     }
 
@@ -465,7 +469,7 @@ export class GatewayClient {
         reasoning_content: reasoningContent,
         tool_calls: [],
         finished_tool_calls: finishedToolCalls,
-        ...(usage ? { usage } : {}),
+        ...(usage ? { usage, usageAvailability: extractUsageAvailability(obj.usage) } : {}),
       };
     }
     if (chunk.message) {
@@ -475,7 +479,7 @@ export class GatewayClient {
         reasoning_content: reasoningContent,
         tool_calls: [],
         finished_tool_calls: finishedToolCalls,
-        ...(usage ? { usage } : {}),
+        ...(usage ? { usage, usageAvailability: extractUsageAvailability(obj.usage) } : {}),
       };
     }
     return null;
@@ -697,6 +701,24 @@ export function extractUsage(raw: unknown): OpenAIUsage | undefined {
 function toNonNegativeNumber(value: unknown, fallback = 0): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) { return fallback; }
   return value < 0 ? 0 : value;
+}
+
+/**
+ * Whether the raw (pre-normalization) usage payload actually included each
+ * field. Read on the same raw object `extractUsage` normalizes, so a server
+ * that omits `prompt_tokens` entirely is distinguishable from one reporting
+ * a real `0` — needed by the per-reply token summary's partial/unavailable
+ * labeling (issue: gateway per-reply token summary).
+ */
+export function extractUsageAvailability(raw: unknown): OpenAIUsageAvailability {
+  if (!raw || typeof raw !== 'object') {
+    return { promptKnown: false, completionKnown: false };
+  }
+  const obj = raw as Record<string, unknown>;
+  return {
+    promptKnown: typeof obj.prompt_tokens === 'number' && Number.isFinite(obj.prompt_tokens),
+    completionKnown: typeof obj.completion_tokens === 'number' && Number.isFinite(obj.completion_tokens),
+  };
 }
 
 function extractServerErrorMessage(payload: ServerErrorPayload): string {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -139,6 +139,18 @@ export interface OpenAIUsage {
   };
 }
 
+/**
+ * Whether the raw usage payload actually included each field, BEFORE
+ * `extractUsage` normalizes a missing value to 0. Lets downstream consumers
+ * (the per-reply token summary) distinguish a genuinely reported zero from
+ * an absent field, without changing the normalized `OpenAIUsage` shape that
+ * VS Code's context-window widget already consumes.
+ */
+export interface OpenAIUsageAvailability {
+  readonly promptKnown: boolean;
+  readonly completionKnown: boolean;
+}
+
 export interface OpenAIChatCompletionResponse {
   id: string;
   object: string;

--- a/src/chat/__tests__/replyTokenUsage.test.ts
+++ b/src/chat/__tests__/replyTokenUsage.test.ts
@@ -1,0 +1,259 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  ReplyTokenUsageTracker,
+  extractReplyIdentity,
+  extractToolResultIds,
+  formatReplyTokenSummaryLine,
+  ReplyIdentity,
+} from '../replyTokenUsage';
+import { OpenAIMessage } from '../../api/types';
+
+const ID: ReplyIdentity = { conversationId: 'conv-1', turnIndex: 0 };
+
+function known(prompt: number, completion: number) {
+  return { promptTokens: prompt, completionTokens: completion, promptKnown: true, completionKnown: true };
+}
+
+describe('extractReplyIdentity', () => {
+  test('accepts a nonempty conversationId and nonnegative safe integer turnIndex', () => {
+    const identity = extractReplyIdentity({ _conversationId: 'abc', _telemetryTurn: 3 });
+    assert.deepEqual(identity, { conversationId: 'abc', turnIndex: 3 });
+  });
+
+  test('rejects missing modelOptions', () => {
+    assert.equal(extractReplyIdentity(undefined), undefined);
+  });
+
+  test('rejects an empty conversationId', () => {
+    assert.equal(extractReplyIdentity({ _conversationId: '', _telemetryTurn: 0 }), undefined);
+  });
+
+  test('rejects a missing conversationId', () => {
+    assert.equal(extractReplyIdentity({ _telemetryTurn: 0 }), undefined);
+  });
+
+  test('rejects a non-string conversationId', () => {
+    assert.equal(extractReplyIdentity({ _conversationId: 42, _telemetryTurn: 0 }), undefined);
+  });
+
+  test('rejects a missing turnIndex', () => {
+    assert.equal(extractReplyIdentity({ _conversationId: 'abc' }), undefined);
+  });
+
+  test('rejects a negative turnIndex', () => {
+    assert.equal(extractReplyIdentity({ _conversationId: 'abc', _telemetryTurn: -1 }), undefined);
+  });
+
+  test('rejects a non-integer turnIndex', () => {
+    assert.equal(extractReplyIdentity({ _conversationId: 'abc', _telemetryTurn: 1.5 }), undefined);
+  });
+
+  test('rejects an unsafe-integer turnIndex', () => {
+    assert.equal(
+      extractReplyIdentity({ _conversationId: 'abc', _telemetryTurn: Number.MAX_SAFE_INTEGER + 1 }),
+      undefined
+    );
+  });
+});
+
+describe('extractToolResultIds', () => {
+  test('collects tool_call_id from role:tool messages only', () => {
+    const messages: OpenAIMessage[] = [
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', tool_calls: [{ id: 'call_1' }] },
+      { role: 'tool', tool_call_id: 'call_1', content: 'result' },
+      { role: 'tool', tool_call_id: 'call_2', content: 'result 2' },
+    ];
+    assert.deepEqual(extractToolResultIds(messages), ['call_1', 'call_2']);
+  });
+
+  test('ignores tool messages with a non-string tool_call_id', () => {
+    const messages: OpenAIMessage[] = [{ role: 'tool', tool_call_id: 5, content: 'x' }];
+    assert.deepEqual(extractToolResultIds(messages), []);
+  });
+
+  test('returns an empty array for no tool messages', () => {
+    assert.deepEqual(extractToolResultIds([{ role: 'user', content: 'hi' }]), []);
+  });
+});
+
+describe('ReplyTokenUsageTracker', () => {
+  test('summarizes a plain single-round reply', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, { usage: known(100, 10), outgoingToolCallIds: [] });
+    assert.deepEqual(tracker.summarize(ID), {
+      kind: 'complete', promptTokens: 100, completionTokens: 10, totalTokens: 110,
+    });
+  });
+
+  test('accumulates usage across sequential tool-call rounds', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, { usage: known(100, 10), outgoingToolCallIds: ['call_1'] });
+    tracker.beginRound(ID, ['call_1']);
+    tracker.recordRound(ID, { usage: known(200, 20), outgoingToolCallIds: ['call_2'] });
+    tracker.beginRound(ID, ['call_2']);
+    tracker.recordRound(ID, { usage: known(300, 30), outgoingToolCallIds: [] });
+    assert.deepEqual(tracker.summarize(ID), {
+      kind: 'complete', promptTokens: 600, completionTokens: 60, totalTokens: 660,
+    });
+  });
+
+  test('counts a parallel tool-call batch once, not once per result', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, { usage: known(100, 10), outgoingToolCallIds: ['call_1', 'call_2'] });
+    // Both tool results answer the SAME preceding round.
+    tracker.beginRound(ID, ['call_1', 'call_2']);
+    tracker.recordRound(ID, { usage: known(150, 15), outgoingToolCallIds: [] });
+    assert.deepEqual(tracker.summarize(ID), {
+      kind: 'complete', promptTokens: 250, completionTokens: 25, totalTokens: 275,
+    });
+  });
+
+  test('starts a fresh chain when incoming tool-result IDs do not match the pending round', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, { usage: known(100, 10), outgoingToolCallIds: ['call_1'] });
+    // Unrelated identity reuse (e.g. a stray/mismatched continuation) discards the prior partial chain.
+    tracker.beginRound(ID, ['unrelated_call']);
+    tracker.recordRound(ID, { usage: known(50, 5), outgoingToolCallIds: [] });
+    assert.deepEqual(tracker.summarize(ID), {
+      kind: 'complete', promptTokens: 50, completionTokens: 5, totalTokens: 55,
+    });
+  });
+
+  test('isolates two concurrent chats with different conversation IDs', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    const idA: ReplyIdentity = { conversationId: 'conv-a', turnIndex: 0 };
+    const idB: ReplyIdentity = { conversationId: 'conv-b', turnIndex: 0 };
+    tracker.beginRound(idA, []);
+    tracker.recordRound(idA, { usage: known(10, 1), outgoingToolCallIds: [] });
+    tracker.beginRound(idB, []);
+    tracker.recordRound(idB, { usage: known(20, 2), outgoingToolCallIds: [] });
+    assert.deepEqual(tracker.summarize(idA), { kind: 'complete', promptTokens: 10, completionTokens: 1, totalTokens: 11 });
+    assert.deepEqual(tracker.summarize(idB), { kind: 'complete', promptTokens: 20, completionTokens: 2, totalTokens: 22 });
+  });
+
+  test('isolates a second reply (new turnIndex) after finish() clears the first', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, { usage: known(10, 1), outgoingToolCallIds: [] });
+    tracker.finish(ID);
+    const nextTurn: ReplyIdentity = { conversationId: ID.conversationId, turnIndex: ID.turnIndex + 1 };
+    tracker.beginRound(nextTurn, []);
+    tracker.recordRound(nextTurn, { usage: known(30, 3), outgoingToolCallIds: [] });
+    assert.deepEqual(tracker.summarize(nextTurn), { kind: 'complete', promptTokens: 30, completionTokens: 3, totalTokens: 33 });
+    assert.deepEqual(tracker.summarize(ID), { kind: 'unavailable' });
+  });
+
+  test('marks the summary partial when one round is missing usage entirely', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, { usage: known(100, 10), outgoingToolCallIds: ['call_1'] });
+    tracker.beginRound(ID, ['call_1']);
+    tracker.recordRound(ID, { usage: undefined, outgoingToolCallIds: [] });
+    assert.deepEqual(tracker.summarize(ID), {
+      kind: 'partial', promptTokens: 100, completionTokens: 10, totalTokens: 110,
+    });
+  });
+
+  test('marks the summary partial when only one field of a round is known', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, {
+      usage: { promptTokens: 100, completionTokens: 0, promptKnown: true, completionKnown: false },
+      outgoingToolCallIds: [],
+    });
+    assert.deepEqual(tracker.summarize(ID), {
+      kind: 'partial', promptTokens: 100, completionTokens: 0, totalTokens: 100,
+    });
+  });
+
+  test('reports unavailable when no round ever reported usage', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, { usage: undefined, outgoingToolCallIds: [] });
+    assert.deepEqual(tracker.summarize(ID), { kind: 'unavailable' });
+  });
+
+  test('reports unavailable for an identity that was never begun', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    assert.deepEqual(tracker.summarize(ID), { kind: 'unavailable' });
+  });
+
+  test('recordRound is a no-op without a matching beginRound', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.recordRound(ID, { usage: known(100, 10), outgoingToolCallIds: [] });
+    assert.deepEqual(tracker.summarize(ID), { kind: 'unavailable' });
+  });
+
+  test('sanitizes negative and non-finite reported numbers to zero', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, {
+      usage: { promptTokens: -5, completionTokens: NaN, promptKnown: true, completionKnown: true },
+      outgoingToolCallIds: [],
+    });
+    assert.deepEqual(tracker.summarize(ID), { kind: 'complete', promptTokens: 0, completionTokens: 0, totalTokens: 0 });
+  });
+
+  test('floors fractional reported numbers', () => {
+    const tracker = new ReplyTokenUsageTracker();
+    tracker.beginRound(ID, []);
+    tracker.recordRound(ID, {
+      usage: { promptTokens: 10.9, completionTokens: 5.1, promptKnown: true, completionKnown: true },
+      outgoingToolCallIds: [],
+    });
+    assert.deepEqual(tracker.summarize(ID), { kind: 'complete', promptTokens: 10, completionTokens: 5, totalTokens: 15 });
+  });
+
+  test('evicts the oldest inactive chain once the bound is exceeded, keeping in-flight chains', () => {
+    const tracker = new ReplyTokenUsageTracker(2);
+    const idA: ReplyIdentity = { conversationId: 'a', turnIndex: 0 };
+    const idB: ReplyIdentity = { conversationId: 'b', turnIndex: 0 };
+    const idC: ReplyIdentity = { conversationId: 'c', turnIndex: 0 };
+    // idA finishes a round (inFlight back to 0) and becomes the oldest evictable chain.
+    tracker.beginRound(idA, []);
+    tracker.recordRound(idA, { usage: known(1, 1), outgoingToolCallIds: [] });
+    // idB stays in-flight (beginRound only, no recordRound yet).
+    tracker.beginRound(idB, []);
+    // idC pushes the tracker over its cap of 2.
+    tracker.beginRound(idC, []);
+    tracker.recordRound(idC, { usage: known(3, 3), outgoingToolCallIds: [] });
+
+    assert.equal(tracker.size, 2);
+    assert.deepEqual(tracker.summarize(idA), { kind: 'unavailable' });
+    assert.deepEqual(tracker.summarize(idC), { kind: 'complete', promptTokens: 3, completionTokens: 3, totalTokens: 6 });
+  });
+});
+
+describe('formatReplyTokenSummaryLine', () => {
+  test('formats a complete summary with thousands separators', () => {
+    const line = formatReplyTokenSummaryLine({
+      kind: 'complete', promptTokens: 12345, completionTokens: 1234, totalTokens: 13579,
+    });
+    assert.equal(line, 'Tokens: input 12,345 | output 1,234 | total 13,579');
+  });
+
+  test('formats a partial summary with the partial label', () => {
+    const line = formatReplyTokenSummaryLine({
+      kind: 'partial', promptTokens: 100, completionTokens: 10, totalTokens: 110,
+    });
+    assert.equal(line, 'Tokens (partial): input 100 | output 10 | total 110');
+  });
+
+  test('formats an unavailable summary', () => {
+    assert.equal(
+      formatReplyTokenSummaryLine({ kind: 'unavailable' }),
+      'Tokens: input unavailable | output unavailable | total unavailable'
+    );
+  });
+
+  test('formats small numbers without a separator', () => {
+    const line = formatReplyTokenSummaryLine({ kind: 'complete', promptTokens: 5, completionTokens: 0, totalTokens: 5 });
+    assert.equal(line, 'Tokens: input 5 | output 0 | total 5');
+  });
+});

--- a/src/chat/replyTokenUsage.ts
+++ b/src/chat/replyTokenUsage.ts
@@ -1,0 +1,209 @@
+/**
+ * Tracks server-reported token usage across the internal tool-call rounds of
+ * ONE Copilot reply, so a final summary line can show input/output/total
+ * tokens for that reply instead of Copilot's native credits footer.
+ *
+ * VS Code's stable `LanguageModelChatProvider` API gives each round its own
+ * `handle()` call with no public reply/turn identifier — see
+ * `/memories/session/plan.md` for the full compatibility analysis. Rounds are
+ * linked using two fields the installed Copilot Chat build passes through
+ * `options.modelOptions` (`_conversationId`, `_telemetryTurn`); these are
+ * private and unstable. Callers MUST fail closed: if either field is absent
+ * or malformed, treat the reply as unidentifiable rather than guess.
+ *
+ * This module is pure (no `vscode` import) so it can be unit-tested with
+ * plain data and reused unchanged if the identity source ever changes.
+ */
+
+import { OpenAIMessage } from '../api/types';
+
+export interface ReplyIdentity {
+  readonly conversationId: string;
+  readonly turnIndex: number;
+}
+
+/**
+ * Validate and extract a {@link ReplyIdentity} from a chat request's
+ * `modelOptions`. Returns `undefined` (never a best-guess identity) when
+ * either field is missing or the wrong shape — the caller must not track
+ * usage for that round.
+ */
+export function extractReplyIdentity(
+  modelOptions: Readonly<Record<string, unknown>> | undefined
+): ReplyIdentity | undefined {
+  if (!modelOptions) { return undefined; }
+  const conversationId = modelOptions._conversationId;
+  const turnIndex = modelOptions._telemetryTurn;
+  if (typeof conversationId !== 'string' || conversationId.length === 0) { return undefined; }
+  if (typeof turnIndex !== 'number' || !Number.isSafeInteger(turnIndex) || turnIndex < 0) {
+    return undefined;
+  }
+  return { conversationId, turnIndex };
+}
+
+/** Tool-result `tool_call_id`s a round's outgoing request answers. */
+export function extractToolResultIds(messages: readonly OpenAIMessage[]): string[] {
+  const ids: string[] = [];
+  for (const msg of messages) {
+    if (msg.role === 'tool' && typeof msg.tool_call_id === 'string') {
+      ids.push(msg.tool_call_id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * One round's server-reported usage, plus whether each field was actually
+ * present on the wire (as opposed to defaulted to 0 by normalization). A
+ * known zero is valid data; an absent field is unknown.
+ */
+export interface RoundUsage {
+  readonly promptTokens: number;
+  readonly completionTokens: number;
+  readonly promptKnown: boolean;
+  readonly completionKnown: boolean;
+}
+
+export interface RoundOutcome {
+  /** Usage the server reported this round, or `undefined` if no usage frame arrived at all. */
+  readonly usage?: RoundUsage;
+  /** Tool-call IDs the model emitted this round; empty on a terminal (final-answer) round. */
+  readonly outgoingToolCallIds: readonly string[];
+}
+
+export type ReplyTokenSummary =
+  | { readonly kind: 'complete'; readonly promptTokens: number; readonly completionTokens: number; readonly totalTokens: number }
+  | { readonly kind: 'partial'; readonly promptTokens: number; readonly completionTokens: number; readonly totalTokens: number }
+  | { readonly kind: 'unavailable' };
+
+interface ChainState {
+  promptTokens: number;
+  completionTokens: number;
+  hadAnyUsage: boolean;
+  hadMissingUsage: boolean;
+  pendingToolCallIds: ReadonlySet<string>;
+  inFlight: number;
+  touch: number;
+}
+
+const DEFAULT_MAX_INACTIVE_CHAINS = 128;
+
+function sanitize(n: number): number {
+  if (!Number.isFinite(n) || n < 0) { return 0; }
+  return Math.floor(n);
+}
+
+function chainKey(identity: ReplyIdentity): string {
+  return `${identity.conversationId}\u0000${identity.turnIndex}`;
+}
+
+function emptyChain(): ChainState {
+  return {
+    promptTokens: 0,
+    completionTokens: 0,
+    hadAnyUsage: false,
+    hadMissingUsage: false,
+    pendingToolCallIds: new Set(),
+    inFlight: 0,
+    touch: 0,
+  };
+}
+
+/**
+ * Accumulates usage across the rounds of replies identified by
+ * {@link ReplyIdentity}. One instance is owned by `ChatRequestHandler` for
+ * its whole lifetime; state per reply is bounded and cleared on completion,
+ * never persisted.
+ */
+export class ReplyTokenUsageTracker {
+  private readonly chains = new Map<string, ChainState>();
+  private touchCounter = 0;
+
+  constructor(private readonly maxInactiveChains: number = DEFAULT_MAX_INACTIVE_CHAINS) {}
+
+  /**
+   * Register that a round is starting. `incomingToolResultIds` are the
+   * `tool_call_id`s this round's outgoing request answers — used to confirm
+   * this is really a continuation of the reply's own previous round (rather
+   * than an identity coincidentally reused by something else, e.g. a
+   * subagent), which starts a fresh chain instead of merging into it.
+   */
+  beginRound(identity: ReplyIdentity, incomingToolResultIds: readonly string[]): void {
+    const key = chainKey(identity);
+    const existing = this.chains.get(key);
+    const isContinuation =
+      existing !== undefined &&
+      existing.pendingToolCallIds.size > 0 &&
+      incomingToolResultIds.some((id) => existing.pendingToolCallIds.has(id));
+    const chain = isContinuation && existing ? existing : emptyChain();
+    chain.inFlight++;
+    chain.touch = ++this.touchCounter;
+    this.chains.set(key, chain);
+    this.evictIfNeeded();
+  }
+
+  /** Record a round's outcome. No-ops if `beginRound` was never called for this identity. */
+  recordRound(identity: ReplyIdentity, outcome: RoundOutcome): void {
+    const chain = this.chains.get(chainKey(identity));
+    if (!chain) { return; }
+
+    chain.inFlight = Math.max(0, chain.inFlight - 1);
+
+    const promptKnown = outcome.usage?.promptKnown ?? false;
+    const completionKnown = outcome.usage?.completionKnown ?? false;
+    if (promptKnown) { chain.promptTokens += sanitize(outcome.usage!.promptTokens); }
+    if (completionKnown) { chain.completionTokens += sanitize(outcome.usage!.completionTokens); }
+    chain.hadAnyUsage = chain.hadAnyUsage || promptKnown || completionKnown;
+    chain.hadMissingUsage = chain.hadMissingUsage || !(promptKnown && completionKnown);
+    chain.pendingToolCallIds = new Set(outcome.outgoingToolCallIds);
+    chain.touch = ++this.touchCounter;
+  }
+
+  /** Read the reply's current accumulated totals without clearing state. */
+  summarize(identity: ReplyIdentity): ReplyTokenSummary {
+    const chain = this.chains.get(chainKey(identity));
+    if (!chain || !chain.hadAnyUsage) { return { kind: 'unavailable' }; }
+    const totalTokens = chain.promptTokens + chain.completionTokens;
+    return chain.hadMissingUsage
+      ? { kind: 'partial', promptTokens: chain.promptTokens, completionTokens: chain.completionTokens, totalTokens }
+      : { kind: 'complete', promptTokens: chain.promptTokens, completionTokens: chain.completionTokens, totalTokens };
+  }
+
+  /** Clear a reply's state. Call once its terminal (tool-call-free) round completes. */
+  finish(identity: ReplyIdentity): void {
+    this.chains.delete(chainKey(identity));
+  }
+
+  /** Number of tracked chains (test/diagnostic use only). */
+  get size(): number {
+    return this.chains.size;
+  }
+
+  private evictIfNeeded(): void {
+    if (this.chains.size <= this.maxInactiveChains) { return; }
+    const evictable = [...this.chains.entries()]
+      .filter(([, chain]) => chain.inFlight === 0)
+      .sort((a, b) => a[1].touch - b[1].touch);
+    for (const [key] of evictable) {
+      if (this.chains.size <= this.maxInactiveChains) { break; }
+      this.chains.delete(key);
+    }
+  }
+}
+
+function formatWithCommas(n: number): string {
+  return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+/** Render the final-line summary text for a reply's accumulated usage. */
+export function formatReplyTokenSummaryLine(summary: ReplyTokenSummary): string {
+  if (summary.kind === 'unavailable') {
+    return 'Tokens: input unavailable | output unavailable | total unavailable';
+  }
+  const label = summary.kind === 'partial' ? 'Tokens (partial)' : 'Tokens';
+  return (
+    `${label}: input ${formatWithCommas(summary.promptTokens)} | ` +
+    `output ${formatWithCommas(summary.completionTokens)} | ` +
+    `total ${formatWithCommas(summary.totalTokens)}`
+  );
+}

--- a/src/chat/responseStreamer.ts
+++ b/src/chat/responseStreamer.ts
@@ -9,7 +9,7 @@
  */
 
 import { ThinkingParser, ThinkingChunk } from './thinking';
-import { OpenAIUsage } from '../api/types';
+import { OpenAIUsage, OpenAIUsageAvailability } from '../api/types';
 
 export interface StreamReporter {
   reportText(text: string): void;
@@ -20,9 +20,12 @@ export interface StreamReporter {
    * Report a usage frame from the inference server. Called at most once per
    * stream — the OpenAI convention is to emit a trailing chunk with totals
    * after the last delta. Wired to VS Code's chat context-window widget via
-   * a `LanguageModelDataPart` (issue #24).
+   * a `LanguageModelDataPart` (issue #24). `availability` records which
+   * fields were actually present on the wire, for consumers (the per-reply
+   * token summary) that must distinguish a reported zero from an absent
+   * field.
    */
-  reportUsage(usage: OpenAIUsage): void;
+  reportUsage(usage: OpenAIUsage, availability?: OpenAIUsageAvailability): void;
 }
 
 export interface StreamChunk {
@@ -30,6 +33,7 @@ export interface StreamChunk {
   reasoning_content?: string;
   finished_tool_calls?: Array<{ id: string; name: string; arguments: string }>;
   usage?: OpenAIUsage;
+  usageAvailability?: OpenAIUsageAvailability;
 }
 
 export interface StreamStats {
@@ -140,7 +144,7 @@ function processStreamChunk(
     // across the trailing few chunks. Reporting twice would briefly double
     // VS Code's running context-window count before settling.
     stats.reportedUsage = true;
-    reporter.reportUsage(chunk.usage);
+    reporter.reportUsage(chunk.usage, chunk.usageAvailability);
   }
 
   return inReasoningField;

--- a/src/config/gatewayConfig.ts
+++ b/src/config/gatewayConfig.ts
@@ -38,4 +38,12 @@ export interface GatewayConfig {
   inlineCompletionTimeout: number;
   inlineCompletionMaxPrefixChars: number;
   inlineCompletionMaxSuffixChars: number;
+  /**
+   * Append a `Tokens: input … | output … | total …` line to the end of each
+   * reply, summing server-reported usage across that reply's internal
+   * tool-call rounds. Requires the installed Copilot Chat build to supply
+   * private, unstable per-request identity fields — silently does nothing
+   * (no line, no error) when they're absent. See replyTokenUsage.ts.
+   */
+  showReplyTokenUsage: boolean;
 }

--- a/src/provider/__tests__/configValidation.test.ts
+++ b/src/provider/__tests__/configValidation.test.ts
@@ -32,6 +32,7 @@ function baseConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     inlineCompletionTimeout: 3000,
     inlineCompletionMaxPrefixChars: 4000,
     inlineCompletionMaxSuffixChars: 1000,
+    showReplyTokenUsage: true,
     ...overrides,
   };
 }

--- a/src/provider/__tests__/modelCatalog.test.ts
+++ b/src/provider/__tests__/modelCatalog.test.ts
@@ -38,6 +38,7 @@ function fakeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
     inlineCompletionTimeout: 3000,
     inlineCompletionMaxPrefixChars: 4000,
     inlineCompletionMaxSuffixChars: 1000,
+    showReplyTokenUsage: true,
     ...overrides,
   };
 }

--- a/src/provider/chatRequestHandler.ts
+++ b/src/provider/chatRequestHandler.ts
@@ -21,6 +21,13 @@ import {
   isEmptyStreamResult,
   streamResponse,
 } from '../chat/responseStreamer';
+import {
+  ReplyTokenUsageTracker,
+  RoundUsage,
+  extractReplyIdentity,
+  extractToolResultIds,
+  formatReplyTokenSummaryLine,
+} from '../chat/replyTokenUsage';
 import { friendlyModelName } from '../models/modelDisplay';
 import { TokenUsage } from '../status/sessionStats';
 import { ModelCatalog } from './modelCatalog';
@@ -129,6 +136,16 @@ interface ChatRequestHandlerDeps {
  * sizes, cached model data) lives in the {@link ModelCatalog}.
  */
 export class ChatRequestHandler {
+  /**
+   * Accumulates server-reported usage across one reply's internal tool-call
+   * rounds so a final `Tokens: input … | output … | total …` line can be
+   * appended to the reply. Rounds are linked via private, unstable
+   * `_conversationId` / `_telemetryTurn` fields — see `replyTokenUsage.ts`
+   * for the full compatibility contract. Long-lived like this handler; state
+   * is bounded and cleared per reply, never persisted.
+   */
+  private readonly tokenUsageTracker = new ReplyTokenUsageTracker();
+
   constructor(private readonly deps: ChatRequestHandlerDeps) {}
 
   public async handle(
@@ -152,6 +169,20 @@ export class ChatRequestHandler {
     const openAIMessages = convertAllMessages(messages, config.enableImageInput, log);
     log(`Converted to ${openAIMessages.length} OpenAI messages`);
     this.logMessageStructure(openAIMessages);
+
+    // Fail closed: only track/append a token summary when the installed
+    // Copilot build actually supplies both private identity fields (see
+    // replyTokenUsage.ts). Gating extraction on the setting means a disabled
+    // feature never touches the tracker at all.
+    const replyIdentity = config.showReplyTokenUsage
+      ? extractReplyIdentity(options.modelOptions)
+      : undefined;
+    if (config.showReplyTokenUsage && !replyIdentity) {
+      log(
+        'Reply token summary: no valid _conversationId/_telemetryTurn on this request; skipping (this is expected on Copilot builds that don\'t supply them).'
+      );
+    }
+    const incomingToolResultIds = replyIdentity ? extractToolResultIds(openAIMessages) : [];
 
     const configuredMaxOutput =
       model.maxOutputTokens || TOKEN_CONSTANTS.DEFAULT_OUTPUT_TOKENS;
@@ -266,9 +297,17 @@ export class ChatRequestHandler {
 
       this.logRequest(config, requestOptions);
 
-      const reporter = this.createStreamReporter(trackingProgress, (usage) => {
-        capturedUsage = usage;
-      });
+      if (replyIdentity) {
+        this.tokenUsageTracker.beginRound(replyIdentity, incomingToolResultIds);
+      }
+      const emittedToolCallIds: string[] = [];
+      let roundUsage: RoundUsage | undefined;
+      const reporter = this.createStreamReporter(
+        trackingProgress,
+        (usage) => { capturedUsage = usage; },
+        (round) => { roundUsage = round; },
+        (id) => { emittedToolCallIds.push(id); }
+      );
       const chunks = this.deps.client.streamChatCompletion(requestOptions, token);
       const stats = await streamResponse({
         chunks: chunks as AsyncIterable<StreamChunk>,
@@ -280,6 +319,27 @@ export class ChatRequestHandler {
       log(
         `Completed chat request, received ${stats.totalContentLength} chars, ${stats.totalTextParts} text parts, ${stats.totalToolCalls} tool calls`
       );
+
+      if (replyIdentity) {
+        this.tokenUsageTracker.recordRound(replyIdentity, {
+          usage: roundUsage,
+          outgoingToolCallIds: emittedToolCallIds,
+        });
+        const isTerminalRound = stats.totalToolCalls === 0;
+        if (isTerminalRound) {
+          // Only a genuine visible reply gets the summary appended — not a
+          // cancelled request, an empty-response diagnostic, or a
+          // thinking-force-closed fallback (none of those increment
+          // totalTextParts through the normal text path).
+          if (stats.totalTextParts > 0 && !token.isCancellationRequested) {
+            const summary = this.tokenUsageTracker.summarize(replyIdentity);
+            trackingProgress.report(
+              new vscode.LanguageModelTextPart(`\n\n${formatReplyTokenSummaryLine(summary)}`)
+            );
+          }
+          this.tokenUsageTracker.finish(replyIdentity);
+        }
+      }
 
       if (isEmptyStreamResult(stats)) {
         const toolCount = filteredTools?.length ?? 0;
@@ -418,16 +478,20 @@ export class ChatRequestHandler {
 
   private createStreamReporter(
     progress: vscode.Progress<vscode.LanguageModelResponsePart>,
-    onUsage?: (usage: TokenUsage) => void
+    onUsage?: (usage: TokenUsage) => void,
+    onRoundUsage?: (round: RoundUsage) => void,
+    onToolCallEmitted?: (id: string) => void
   ): StreamReporter {
     return {
       reportText: (text) => progress.report(new vscode.LanguageModelTextPart(text)),
       reportThinking: (text) => progress.report(new vscode.LanguageModelThinkingPart(text)),
       reportThinkingDone: () =>
         progress.report(new vscode.LanguageModelThinkingPart('', '', { vscode_reasoning_done: true })),
-      reportToolCall: (id, name, args) =>
-        progress.report(new vscode.LanguageModelToolCallPart(id, name, args)),
-      reportUsage: (usage) => {
+      reportToolCall: (id, name, args) => {
+        onToolCallEmitted?.(id);
+        progress.report(new vscode.LanguageModelToolCallPart(id, name, args));
+      },
+      reportUsage: (usage, availability) => {
         // VS Code 1.120 picks up token usage emitted as a LanguageModelDataPart
         // with the literal mime type `usage` (see microsoft/vscode#315394).
         // The shape mirrors OpenAI's `usage` object. Surfacing it here makes
@@ -440,6 +504,12 @@ export class ChatRequestHandler {
           prompt: usage.prompt_tokens,
           completion: usage.completion_tokens,
           total: usage.total_tokens,
+        });
+        onRoundUsage?.({
+          promptTokens: usage.prompt_tokens,
+          completionTokens: usage.completion_tokens,
+          promptKnown: availability?.promptKnown ?? true,
+          completionKnown: availability?.completionKnown ?? true,
         });
         const payload = new TextEncoder().encode(JSON.stringify(usage));
         progress.report(new vscode.LanguageModelDataPart(payload, USAGE_DATA_PART_MIME_TYPE));

--- a/src/provider/configService.ts
+++ b/src/provider/configService.ts
@@ -71,6 +71,7 @@ export class ConfigService {
       inlineCompletionTimeout: config.get<number>('inlineCompletionTimeout', 3000),
       inlineCompletionMaxPrefixChars: config.get<number>('inlineCompletionMaxPrefixChars', 4000),
       inlineCompletionMaxSuffixChars: config.get<number>('inlineCompletionMaxSuffixChars', 1000),
+      showReplyTokenUsage: config.get<boolean>('showReplyTokenUsage', true),
     };
   }
 


### PR DESCRIPTION
Sums server-reported input/output tokens across one reply's internal tool-call rounds and appends a Tokens: input ... | output ... | total ... line to the final visible response.

- Correlates rounds via Copilot's private _conversationId/_telemetryTurn request fields; fails closed (no line, no other change) when absent.
- Adds usage-availability tracking (client.ts/types.ts/responseStreamer.ts) so a missing field is distinguished from a reported zero, surfaced as partial/unavailable labels.
- New github.copilot.llm-gateway.showReplyTokenUsage setting (default on).
- Does not touch the native Copilot credits footer, the per-call context-window usage widget, or activation-wide session stats.

This is the implementation of  feature suggestion #88 